### PR TITLE
Add sleep function

### DIFF
--- a/src/common/index.js
+++ b/src/common/index.js
@@ -1,0 +1,1 @@
+export { default as sleep } from './sleep'

--- a/src/common/sleep.js
+++ b/src/common/sleep.js
@@ -1,0 +1,3 @@
+const sleep = async (time) => new Promise((resolve) => setTimeout(() => resolve(), time))
+
+export default sleep

--- a/src/common/sleep.test.js
+++ b/src/common/sleep.test.js
@@ -1,0 +1,15 @@
+import sleep from './sleep'
+
+describe('#sleep()', () => {
+  it('should wait least 100ms', async () => {
+    const start = Date.now()
+    await sleep(100)
+    expect(Date.now() - start).toBeGreaterThanOrEqual(100)
+  })
+
+  it('should wait least 1000ms', async () => {
+    const start = Date.now()
+    await sleep(1000)
+    expect(Date.now() - start).toBeGreaterThanOrEqual(1000)
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ if (!global._babelPolyfill) {
 // eslint-disable-next-line global-require
 // require('source-map-support/register')
 
+const common = require('./common')
 const config = require('./config')
 const data = require('./data')
 const error = require('./error')
@@ -14,6 +15,7 @@ const lang = require('./lang')
 const path = require('./path')
 
 module.exports = {
+  ...common,
   ...config,
   ...data,
   ...error,


### PR DESCRIPTION
This PR adds a sleep function that can be used if some delay is needed before executing another function, e.g. retrying removal.

Example use case: https://github.com/serverless/components/pull/285/files#diff-6795bf000e41af98e7c3371a5da272d9R113