### PR TITLE
Ensure that tests in windows are run using cmd.exe 

### DIFF
--- a/scripts/test-ci.sh
+++ b/scripts/test-ci.sh
@@ -1,3 +1,9 @@
 set -e
-jest . --runInBand --forceExit --colors
+if [ $TRAVIS_OS_NAME = "windows" ]; then
+   echo "running tests in cmd.exe..."
+   cmd.exe /c jest . --runInBand --forceExit --colors
+else
+   echo "running tests in bash..."
+   jest . --runInBand --forceExit --colors
+fi
 codecov


### PR DESCRIPTION
so that we still test the path issues.