### PR TITLE
feat: Add general logging utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,5 @@ npm install @serverless/utils
 - [`analyticsAndNotificationsUrl`](docs/analytics-and-notifications-url.md)
 - [`config`](docs/config.md)
 - [`isInChina`](docs/is-in-china.md)
+- [`log`](docs/log.md)
 - [`processBackendNotificationRequest`](docs/process-backend-notification-request.md)

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,0 +1,31 @@
+# log
+
+## General logging utility
+
+The purpose of `log` is to provide a unified way to emit formatted logs. It outputs messages in form of `<entity>: <formatted message>\n`.
+
+By default, `entity` is set to `Serverless`, but it can be customized. In addition, it supports bolding, underlining and allows to customize colors, as supported by [chalk](https://github.com/chalk/chalk).
+
+```javascript
+const log = require('@serverless/utils/log);
+```
+
+### `log(message)`
+
+Log message with default formatting
+
+### `log(message, { bold: true })`
+
+Log bolded message
+
+### `log(message, { underline: true })`
+
+Log underlined message
+
+### `log(message, { color: 'red' })`
+
+Log message with custom color
+
+### `log(message, { entity: 'Custom' })`
+
+Log message with custom entity

--- a/log.js
+++ b/log.js
@@ -1,0 +1,14 @@
+'use strict';
+const chalk = require('chalk');
+
+module.exports = (message, options = {}) => {
+  const { underline = false, bold = false, color = null, entity = 'Serverless' } = options;
+
+  let print = chalk.yellow;
+
+  if (color) print = chalk.keyword(color);
+  if (underline) print = print.underline;
+  if (bold) print = print.bold;
+
+  process.stdout.write(`${entity}: ${print(message)}\n`);
+};

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "mocha": "^6.2.3",
     "nyc": "^15.1.0",
     "prettier": "^2.1.2",
+    "process-utils": "^4.0.0",
     "sinon": "^8.1.1",
     "standard-version": "^9.0.0"
   },

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const chalk = require('chalk');
+const overrideStdoutWrite = require('process-utils/override-stdout-write');
+const expect = require('chai').expect;
+const log = require('../log');
+
+describe('log', () => {
+  it('supports message without custom options', () => {
+    let stdoutData = '';
+    overrideStdoutWrite(
+      (data) => (stdoutData += data),
+      () => log('basic message')
+    );
+    expect(stdoutData).to.have.string('basic message');
+    expect(stdoutData.startsWith('Serverless')).to.be.true;
+  });
+
+  it('supports message with custom entity', () => {
+    let stdoutData = '';
+    overrideStdoutWrite(
+      (data) => (stdoutData += data),
+      () => log('basic message', { entity: 'NotServerless' })
+    );
+    expect(stdoutData.startsWith('NotServerless')).to.be.true;
+    expect(stdoutData).to.have.string(chalk.yellow('basic message'));
+  });
+
+  it('supports message with custom color', () => {
+    let stdoutData = '';
+    overrideStdoutWrite(
+      (data) => (stdoutData += data),
+      () => log('basic message', { color: 'green' })
+    );
+    expect(stdoutData.startsWith('Serverless')).to.be.true;
+    expect(stdoutData).to.include(chalk.keyword('green')('basic message'));
+  });
+
+  it('supports underlined message', () => {
+    let stdoutData = '';
+    overrideStdoutWrite(
+      (data) => (stdoutData += data),
+      () => log('basic message', { underline: true })
+    );
+    expect(stdoutData.startsWith('Serverless')).to.be.true;
+    expect(stdoutData).to.have.string(chalk.yellow.underline('basic message'));
+  });
+
+  it('supports bolded message', () => {
+    let stdoutData = '';
+    overrideStdoutWrite(
+      (data) => (stdoutData += data),
+      () => log('basic message', { bold: true })
+    );
+    expect(stdoutData.startsWith('Serverless')).to.be.true;
+    expect(stdoutData).to.have.string(chalk.yellow.bold('basic message'));
+  });
+});


### PR DESCRIPTION
Adds general logging utility that will be used by `serverless/serverless` (and potentially other projects in the future) as specified in https://github.com/serverless/serverless/issues/8444


Closes: #63