### PR TITLE
feat(Config): Introduce new config resolution

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1,10 +1,12 @@
 # config
 
-## Handler of user config files (stored in `.sererlessrc`)
+## Handler of user config files (stored in `.serverlessrc`)
 
-By default config is stored in home directory, but user may host it in any other location as supported by [rc search rules](https://github.com/dominictarr/rc#standards)
+By default, global config is stored in home directory, but user can also store it in `~/.config`. In addition, local config is recognized if it's present in current directory. On resolution, values from both global and local configs will be merged, with local config values overriding global ones.
 
-Ensures no exception on eventual access issues (altough errors are logged with `SLS_DEBUG` env var on).
+When using `delete` or `set`, only one underlying config file will be modified. If local config file is present, it will be modified. Otherwise, global config will be modified.
+
+Ensures no exception on eventual access issues (altough errors are logged with `SLS_DEBUG` env var on). If malformed config will be encountered, it will be renamed to `.serverlessrc.bak` and in case of global configuration, it will be recreated with default values under `~/.serverlessrc`. If local config is malformed, it won't be recreated.
 
 ```javascript
 const config = require('@serverless/utils/config');
@@ -14,20 +16,39 @@ Exposes following _sync_ access methods:
 
 ### `get(propertyPath)`
 
-Retrieve stored property
+Retrieve stored property. It supports nested paths as well.
 
 ### `set(propertyPath, value)`
 
-Store given property (can be any JSON value)
+Store given property (can be any JSON value).
+
+### `set(object)`
+
+Merge provided `object` with existing config.
 
 ### `delete(propertyPath)`
 
-Delete given property
+Delete given property. It supports nested paths as well.
+
+### `delete(arrayOfPropertyPaths)`
+
+Delete all properties in provided `arrayOfPropertyPaths`. It supports nested paths as well.
 
 ### `getConfig()`
 
-Returns whole structure of config file, if it encounters an error while trying to read config with `rc`, it falls back to `getGlobalConfig()`
+Returns whole config structure (merged if both local and global configs found)
 
-### `getGlobalConfig()`
+### `getLoggedInUser()`
 
-Returns whole structure of global `~/.serverlessrc` config. If it encounters an issue when trying to parse the global config, it renames it to `~/.serverlessrc.bak` and recreates default config under `~/.serverlessrc`
+Returns details about currently logged in user (based on `userId` value in config).
+
+Example result:
+
+```javascript
+{
+  idToken: 'user-id-token',
+  accessKeys: ['first-access-key', 'second-access-key'],
+  username: 'exampleUser',
+  userId: 'example-user-id',
+}
+```

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "js-yaml": "^4.0.0",
     "lodash": "^4.17.20",
     "ncjsm": "^4.1.0",
-    "rc": "^1.2.8",
     "type": "^2.1.0",
     "uuid": "^8.3.2",
     "write-file-atomic": "^3.0.3"
@@ -21,6 +20,7 @@
     "@serverless/eslint-config": "^3.0.0",
     "@serverless/test": "^7.0.0",
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "eslint": "^7.17.0",
     "eslint-plugin-import": "^2.22.1",
     "git-list-updated": "^1.2.1",
@@ -32,7 +32,8 @@
     "prettier": "^2.2.1",
     "process-utils": "^4.0.0",
     "sinon": "^9.2.2",
-    "standard-version": "^9.1.0"
+    "standard-version": "^9.1.0",
+    "timers-ext": "^0.1.7"
   },
   "eslintConfig": {
     "extends": "@serverless/eslint-config/node",

--- a/test/config.js
+++ b/test/config.js
@@ -1,88 +1,661 @@
 'use strict';
 
-const { expect } = require('chai');
+const overrideStdoutWrite = require('process-utils/override-stdout-write');
+const chai = require('chai');
 const config = require('../config');
 const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+chai.use(require('chai-as-promised'));
+const expect = require('chai').expect;
 
 describe('config', () => {
-  it('should have CONFIG_FILE_PATH', () => {
-    const configPath = config.CONFIG_FILE_PATH;
-    expect(configPath).to.exist; // eslint-disable-line
+  it('should have CONFIG_FILE_NAME', () => {
+    const configFilename = config.CONFIG_FILE_NAME;
+    expect(configFilename).to.exist;
   });
 
-  describe('When using config.getConfig', () => {
-    it('should have userId key', () => {
-      const conf = config.getConfig();
-      expect(conf).to.have.nested.property('userId');
+  describe('for both global config in homedir and in ~/.config existing', () => {
+    const homeConfigGlobalConfig = {
+      trackingDisabled: true,
+    };
+    const defaultGlobalConfig = {
+      trackingDisabled: false,
+      enterpriseDisabled: true,
+    };
+    let homeConfigGlobalConfigPath;
+    let defaultGlobalConfigPath;
+    let configFileDir;
+
+    before(async () => {
+      await fs.promises.mkdir('local');
+      process.chdir('local');
+      configFileDir = path.join(os.homedir(), '.config');
+      await fs.promises.mkdir(configFileDir);
+      homeConfigGlobalConfigPath = path.join(configFileDir, config.CONFIG_FILE_NAME);
+      defaultGlobalConfigPath = path.join(os.homedir(), config.CONFIG_FILE_NAME);
+      await Promise.all([
+        fs.promises.writeFile(
+          homeConfigGlobalConfigPath,
+          JSON.stringify(homeConfigGlobalConfig, null, 2)
+        ),
+        fs.promises.writeFile(
+          defaultGlobalConfigPath,
+          JSON.stringify(defaultGlobalConfig, null, 2)
+        ),
+      ]);
     });
 
-    it('should have frameworkId key', () => {
-      const conf = config.getConfig();
-      expect(conf).to.have.nested.property('frameworkId');
+    after(async () => {
+      await Promise.all([
+        fs.promises.unlink(homeConfigGlobalConfigPath),
+        fs.promises.unlink(defaultGlobalConfigPath),
+      ]);
+      await fs.promises.rmdir(configFileDir);
+      process.chdir(os.homedir());
+      await fs.promises.rmdir(path.join(os.homedir(), 'local'));
     });
 
-    it('should have trackingDisabled key', () => {
-      const conf = config.getConfig();
-      expect(conf).to.have.nested.property('trackingDisabled');
+    it('should use only default global config', () => {
+      const result = config.getConfig();
+
+      expect(result).to.deep.equal(defaultGlobalConfig);
+    });
+
+    it('should emit warning about two global config files', () => {
+      let stdoutData = '';
+      overrideStdoutWrite(
+        (data) => (stdoutData += data),
+        () => {
+          config.getConfig();
+        }
+      );
+
+      expect(stdoutData).to.include('Found two global configuration files');
+      expect(stdoutData).to.include(`Using: ${defaultGlobalConfigPath}`);
     });
   });
 
-  describe('When using config.get', () => {
-    it('should have frameworkId', () => {
-      const frameworkId = config.get('frameworkId');
-      expect(frameworkId).to.exist; // eslint-disable-line
+  describe('for both local and global config in homedir existing', () => {
+    const localConfig = {
+      trackingDisabled: true,
+    };
+    const globalConfig = {
+      trackingDisabled: false,
+      enterpriseDisabled: true,
+    };
+    let localConfigPath;
+    let globalConfigPath;
+
+    before(async () => {
+      await fs.promises.mkdir('local');
+      process.chdir('local');
+      localConfigPath = path.join(process.cwd(), config.CONFIG_FILE_NAME);
+      globalConfigPath = path.join(os.homedir(), config.CONFIG_FILE_NAME);
+      await Promise.all([
+        fs.promises.writeFile(localConfigPath, JSON.stringify(localConfig, null, 2)),
+        fs.promises.writeFile(globalConfigPath, JSON.stringify(globalConfig, null, 2)),
+      ]);
     });
-    it('should have not have a value that doesnt exist', () => {
-      const doesntExist = config.get('frameworkIdzzzz');
-      expect(doesntExist).to.not.exist; // eslint-disable-line
+
+    after(async () => {
+      await Promise.all([
+        fs.promises.unlink(localConfigPath),
+        fs.promises.unlink(globalConfigPath),
+      ]);
+      process.chdir(os.homedir());
+      await fs.promises.rmdir(path.join(os.homedir(), 'local'));
+    });
+
+    it('should return merged config', () => {
+      const result = config.getConfig();
+
+      expect(result).to.deep.equal({
+        trackingDisabled: true,
+        enterpriseDisabled: true,
+      });
+    });
+
+    it('should include values from global config file', () => {
+      const result = config.get('enterpriseDisabled');
+      expect(result).to.be.true;
+    });
+
+    it('should prefer values from local over global config', () => {
+      const result = config.get('trackingDisabled');
+      expect(result).to.be.true;
+    });
+
+    it('should not have a value that does not exist in both configs ', () => {
+      const result = config.get('nonexistentKey');
+      expect(result).to.be.undefined;
+    });
+
+    it('when setting a new value, it should update only local config', async () => {
+      config.set('newKey', 'somevalue');
+      const localConfigContent = await fs.promises.readFile(localConfigPath, 'utf-8');
+      expect(JSON.parse(localConfigContent).newKey).to.equal('somevalue');
+      const globalConfigContent = await fs.promises.readFile(globalConfigPath, 'utf-8');
+      expect(JSON.parse(globalConfigContent)).to.not.have.property('newKey');
+    });
+
+    it('when deleting a value, it should update only local config', async () => {
+      config.delete('trackingDisabled');
+      const localConfigContent = await fs.promises.readFile(localConfigPath, 'utf-8');
+      expect(JSON.parse(localConfigContent)).to.not.have.property('trackingDisabled');
+      const globalConfigContent = await fs.promises.readFile(globalConfigPath, 'utf-8');
+      expect(JSON.parse(globalConfigContent)).to.have.property('trackingDisabled');
     });
   });
 
-  describe('When using config.set', () => {
-    it('should add new properties with "set"', () => {
-      config.set('foo', true);
-      const foo = config.get('foo');
-      expect(foo).to.equal(true);
+  describe('for only local config existing beforehand', () => {
+    const localConfig = {
+      trackingDisabled: true,
+    };
+    let localConfigPath;
+    let globalConfigPath;
+
+    before(async () => {
+      await fs.promises.mkdir('local');
+      process.chdir('local');
+      localConfigPath = path.join(process.cwd(), config.CONFIG_FILE_NAME);
+      await fs.promises.writeFile(localConfigPath, JSON.stringify(localConfig, null, 2));
+      globalConfigPath = path.join(os.homedir(), config.CONFIG_FILE_NAME);
     });
 
-    it('should delete properties with "delete"', () => {
-      // cleanup foo
-      config.delete('foo');
-      const zaz = config.get('foo');
-      expect(zaz).to.equal(undefined);
+    after(async () => {
+      await Promise.all([
+        fs.promises.unlink(localConfigPath),
+        fs.promises.unlink(globalConfigPath),
+      ]);
+      process.chdir(os.homedir());
+      await fs.promises.rmdir(path.join(os.homedir(), 'local'));
+    });
+
+    it('should return merged config', () => {
+      const result = config.getConfig();
+
+      expect(result).to.have.property('frameworkId');
+      expect(result.meta.created_at).not.to.be.null;
+      expect(result.meta.updated_at).not.to.be.null;
+      delete result.frameworkId;
+      delete result.meta;
+      expect(result).to.deep.equal({
+        trackingDisabled: true,
+        enterpriseDisabled: false,
+        userId: null,
+      });
+    });
+
+    it('should include values from default global config file', () => {
+      const result = config.get('enterpriseDisabled');
+      expect(result).to.be.false;
+    });
+
+    it('should prefer values from local over global config', () => {
+      const result = config.get('trackingDisabled');
+      expect(result).to.be.true;
+    });
+
+    it('should not have a value that does not exist in both configs ', () => {
+      const result = config.get('nonexistentKey');
+      expect(result).to.be.undefined;
+    });
+
+    it('when setting a new value, it should update only local config', async () => {
+      config.set('newKey', 'somevalue');
+      const localConfigContent = await fs.promises.readFile(localConfigPath, 'utf-8');
+      expect(JSON.parse(localConfigContent).newKey).to.equal('somevalue');
+      const globalConfigContent = await fs.promises.readFile(globalConfigPath, 'utf-8');
+      expect(JSON.parse(globalConfigContent)).to.not.have.property('newKey');
+    });
+
+    it('when deleting a value, it should update only local config', async () => {
+      config.delete('trackingDisabled');
+      const localConfigContent = await fs.promises.readFile(localConfigPath, 'utf-8');
+      expect(JSON.parse(localConfigContent)).to.not.have.property('trackingDisabled');
+      const globalConfigContent = await fs.promises.readFile(globalConfigPath, 'utf-8');
+      expect(JSON.parse(globalConfigContent)).to.have.property('trackingDisabled');
     });
   });
-});
 
-describe('malformed config', () => {
-  const malformedConfigJson = '{"userId":null';
-  const backupConfigFilePath = `${config.CONFIG_FILE_PATH}.bak`;
+  describe('for no config file existing beforehand', () => {
+    let globalConfigPath;
 
-  beforeEach(async () => {
-    await fs.promises.writeFile(config.CONFIG_FILE_PATH, malformedConfigJson);
+    before(async () => {
+      globalConfigPath = path.join(os.homedir(), config.CONFIG_FILE_NAME);
+    });
+
+    after(async () => {
+      await fs.promises.unlink(globalConfigPath);
+    });
+
+    it('should create default config file in homedir during get', async () => {
+      config.get('notImportant');
+      const stat = await fs.promises.stat(globalConfigPath);
+      expect(stat.isFile()).to.be.true;
+    });
+
+    it('should return default config', () => {
+      const result = config.getConfig();
+
+      expect(result).to.have.property('frameworkId');
+      expect(result.meta.created_at).not.to.be.null;
+      expect(result.meta.updated_at).not.to.be.null;
+      delete result.frameworkId;
+      delete result.meta;
+      expect(result).to.deep.equal({
+        trackingDisabled: false,
+        enterpriseDisabled: false,
+        userId: null,
+      });
+    });
+
+    it('should include values from default global config file', () => {
+      const result = config.get('enterpriseDisabled');
+      expect(result).to.be.false;
+    });
+
+    it('should not have a value that does not exist in config', () => {
+      const result = config.get('nonexistentKey');
+      expect(result).to.be.undefined;
+    });
+
+    it('when setting a new value, it should properly update config file', async () => {
+      config.set('newKey', 'somevalue');
+      const globalConfigContent = await fs.promises.readFile(globalConfigPath, 'utf-8');
+      expect(JSON.parse(globalConfigContent).newKey).to.equal('somevalue');
+    });
+
+    it('when deleting a value, it should properly update config file', async () => {
+      config.delete('trackingDisabled');
+      const globalConfigContent = await fs.promises.readFile(globalConfigPath, 'utf-8');
+      expect(JSON.parse(globalConfigContent)).to.not.have.property('trackingDisabled');
+    });
   });
 
-  afterEach(async () => {
-    await fs.promises.unlink(backupConfigFilePath);
+  describe('for global config file in .config directory', () => {
+    const globalConfig = {
+      trackingDisabled: false,
+      enterpriseDisabled: true,
+    };
+    let globalConfigPath;
+    let configFileDir;
+
+    before(async () => {
+      configFileDir = path.join(os.homedir(), '.config');
+      await fs.promises.mkdir(configFileDir);
+      globalConfigPath = path.join(configFileDir, config.CONFIG_FILE_NAME);
+      await fs.promises.writeFile(globalConfigPath, JSON.stringify(globalConfig, null, 2));
+    });
+
+    after(async () => {
+      await fs.promises.unlink(globalConfigPath);
+      await fs.promises.rmdir(configFileDir);
+    });
+
+    it('should not create default config file in homedir', async () => {
+      config.get('notImportant');
+      await expect(
+        fs.promises.stat(path.join(os.homedir(), config.CONFIG_FILE_NAME))
+      ).to.be.eventually.rejected.and.have.property('code', 'ENOENT');
+    });
+
+    it('should correctly return existing values', () => {
+      const result = config.get('trackingDisabled');
+      expect(result).to.be.false;
+    });
+
+    it('should not have a value that does not exist in config', () => {
+      const result = config.get('nonexistentKey');
+      expect(result).to.be.undefined;
+    });
+
+    it('when setting a new value, it should properly update config file', async () => {
+      config.set('newKey', 'somevalue');
+      const globalConfigContent = await fs.promises.readFile(globalConfigPath, 'utf-8');
+      expect(JSON.parse(globalConfigContent).newKey).to.equal('somevalue');
+    });
+
+    it('when deleting a value, it should properly update config file', async () => {
+      config.delete('trackingDisabled');
+      const globalConfigContent = await fs.promises.readFile(globalConfigPath, 'utf-8');
+      expect(JSON.parse(globalConfigContent)).to.not.have.property('trackingDisabled');
+    });
   });
 
-  it('should handle malformed config file and fallback to getGlobalConfig', async () => {
-    const conf = config.getConfig();
+  describe('set scenarios', () => {
+    const globalConfig = {
+      trackingDisabled: false,
+      enterpriseDisabled: true,
+      items: {
+        id1: {
+          name: 'John',
+        },
+        id2: {
+          name: 'James',
+        },
+      },
+    };
+    let globalConfigPath;
 
-    const configFile = await fs.promises.readFile(config.CONFIG_FILE_PATH);
-    expect(JSON.parse(configFile)).to.deep.equal(conf);
+    before(async () => {
+      globalConfigPath = path.join(os.homedir(), config.CONFIG_FILE_NAME);
+      await fs.promises.writeFile(globalConfigPath, JSON.stringify(globalConfig, null, 2));
+    });
+
+    after(async () => {
+      await fs.promises.unlink(globalConfigPath);
+    });
+
+    it('should work correctly for key-value pair provided', () => {
+      config.set('newKey', 'somevalue');
+      const resultConfig = config.getConfig();
+
+      expect(resultConfig.newKey).to.equal('somevalue');
+    });
+
+    it('should work correctly for provided object', () => {
+      const updateData = {
+        trackingDisabled: true,
+        items: {
+          id3: {
+            name: 'Joshua',
+          },
+        },
+      };
+      config.set(updateData);
+      const resultConfig = config.getConfig();
+
+      expect(resultConfig.trackingDisabled).to.be.true;
+      expect(resultConfig.items).to.deep.equal({
+        id1: {
+          name: 'John',
+        },
+        id2: {
+          name: 'James',
+        },
+        id3: {
+          name: 'Joshua',
+        },
+      });
+    });
+
+    it('should set updated_at property', () => {
+      config.set('newKey', 'somevalue');
+      const resultConfig = config.getConfig();
+      expect(resultConfig.meta.updated_at).not.to.be.null;
+    });
   });
 
-  it('should handle malformed config file and regenerate it when using getGlobalConfig', async () => {
-    const conf = config.getGlobalConfig();
+  describe('delete scenarios', () => {
+    const globalConfig = {
+      trackingDisabled: false,
+      enterpriseDisabled: true,
+      items: {
+        id1: {
+          name: 'John',
+        },
+        id2: {
+          name: 'James',
+        },
+      },
+      otherItems: {
+        firstKey: {
+          prop: 'nested',
+        },
+        secondKey: {
+          prop: 'secondnested',
+        },
+      },
+    };
+    let globalConfigPath;
 
-    expect(conf).to.not.be.empty;
+    before(async () => {
+      globalConfigPath = path.join(os.homedir(), config.CONFIG_FILE_NAME);
+      await fs.promises.writeFile(globalConfigPath, JSON.stringify(globalConfig, null, 2));
+    });
 
-    const [backupConfigFile, regeneratedConfigFile] = await Promise.all([
-      fs.promises.readFile(backupConfigFilePath, 'utf-8'),
-      fs.promises.readFile(config.CONFIG_FILE_PATH),
-    ]);
-    expect(backupConfigFile).to.equal(malformedConfigJson);
-    expect(JSON.parse(regeneratedConfigFile)).to.deep.equal(conf);
+    after(async () => {
+      await fs.promises.unlink(globalConfigPath);
+    });
+
+    it('should remove plain key', () => {
+      config.delete('trackingDisabled');
+      const resultConfig = config.getConfig();
+
+      expect(resultConfig).to.not.have.property('trackingDisabled');
+    });
+
+    it('should work correctly for nested key', () => {
+      config.delete('items.id1');
+      const resultConfig = config.getConfig();
+
+      expect(resultConfig.items).to.deep.equal({
+        id2: {
+          name: 'James',
+        },
+      });
+    });
+
+    it('should work correctly for array of keys', () => {
+      config.delete(['otherItems.secondKey', 'enterpriseDisabled']);
+      const resultConfig = config.getConfig();
+
+      expect(resultConfig).to.not.have.property('enterpriseDisabled');
+      expect(resultConfig.otherItems).to.deep.equal({
+        firstKey: {
+          prop: 'nested',
+        },
+      });
+    });
+
+    it('should set updated_at property', () => {
+      config.delete('items');
+      const resultConfig = config.getConfig();
+      expect(resultConfig.meta.updated_at).not.to.be.null;
+    });
+  });
+
+  describe('with malformed config files', () => {
+    const malformedConfigJson = '{"userId":null';
+    const backupConfigFilename = `${config.CONFIG_FILE_NAME}.bak`;
+
+    describe('for malformed local config', () => {
+      let localConfigFilePath;
+
+      before(async () => {
+        await fs.promises.mkdir('local');
+        process.chdir('local');
+        localConfigFilePath = path.join(process.cwd(), config.CONFIG_FILE_NAME);
+        await fs.promises.writeFile(localConfigFilePath, malformedConfigJson);
+      });
+
+      after(async () => {
+        await fs.promises.unlink(path.join(process.cwd(), backupConfigFilename));
+        process.chdir(os.homedir());
+        await fs.promises.rmdir(path.join(os.homedir(), 'local'));
+      });
+
+      it('should handle malformed config and move it to backup file', async () => {
+        let conf;
+        let stdoutData = '';
+        overrideStdoutWrite(
+          (data) => (stdoutData += data),
+          () => {
+            conf = config.getConfig();
+          }
+        );
+
+        expect(conf).to.not.be.empty;
+
+        const backupConfigFile = await fs.promises.readFile(
+          path.join(process.cwd(), backupConfigFilename),
+          'utf-8'
+        );
+        expect(backupConfigFile).to.equal(malformedConfigJson);
+        await expect(
+          fs.promises.stat(localConfigFilePath)
+        ).to.be.eventually.rejected.and.have.property('code', 'ENOENT');
+        expect(stdoutData).to.include('Cannot resolve local config file');
+        expect(stdoutData).to.include('Your previous local config was renamed');
+      });
+    });
+
+    describe('for global config in homedir', () => {
+      let configFilePath;
+
+      before(async () => {
+        await fs.promises.mkdir('local');
+        process.chdir('local');
+        configFilePath = path.join(os.homedir(), config.CONFIG_FILE_NAME);
+        await fs.promises.writeFile(configFilePath, malformedConfigJson);
+      });
+
+      after(async () => {
+        await fs.promises.unlink(configFilePath);
+        process.chdir(os.homedir());
+        await fs.promises.rmdir(path.join(os.homedir(), 'local'));
+      });
+
+      it('should handle malformed config file and regenerate it', async () => {
+        let conf;
+        let stdoutData = '';
+        overrideStdoutWrite(
+          (data) => (stdoutData += data),
+          () => {
+            conf = config.getConfig();
+          }
+        );
+
+        expect(conf).to.not.be.empty;
+
+        const [backupConfigFile, regeneratedConfigFile] = await Promise.all([
+          fs.promises.readFile(path.join(os.homedir(), backupConfigFilename), 'utf-8'),
+          fs.promises.readFile(configFilePath),
+        ]);
+        expect(backupConfigFile).to.equal(malformedConfigJson);
+        expect(JSON.parse(regeneratedConfigFile)).to.deep.equal(conf);
+
+        expect(stdoutData).to.include('Cannot resolve global config file');
+        expect(stdoutData).to.include('Your previous global config was renamed');
+        expect(stdoutData).to.include('Default global config will be recreated');
+      });
+    });
+
+    describe('for global config in ~/.config dir', () => {
+      let configFilePath;
+      let configFileDir;
+
+      before(async () => {
+        configFileDir = path.join(os.homedir(), '.config');
+        await fs.promises.mkdir(configFileDir);
+        configFilePath = path.join(configFileDir, config.CONFIG_FILE_NAME);
+        await fs.promises.writeFile(configFilePath, malformedConfigJson);
+      });
+
+      after(async () => {
+        await Promise.all([
+          fs.promises.unlink(`${configFilePath}.bak`),
+          fs.promises.unlink(path.join(os.homedir(), config.CONFIG_FILE_NAME)),
+        ]);
+        await fs.promises.rmdir(configFileDir);
+      });
+
+      it('should handle malformed config file and regenerate it in default global location', async () => {
+        let conf;
+        let stdoutData = '';
+        overrideStdoutWrite(
+          (data) => (stdoutData += data),
+          () => {
+            conf = config.getConfig();
+          }
+        );
+
+        expect(conf).to.not.be.empty;
+
+        const [backupConfigFile, regeneratedConfigFile] = await Promise.all([
+          fs.promises.readFile(path.join(configFileDir, backupConfigFilename), 'utf-8'),
+          fs.promises.readFile(path.join(os.homedir(), config.CONFIG_FILE_NAME)),
+        ]);
+        expect(backupConfigFile).to.equal(malformedConfigJson);
+        expect(JSON.parse(regeneratedConfigFile)).to.deep.equal(conf);
+
+        expect(stdoutData).to.include('Cannot resolve global config file');
+        expect(stdoutData).to.include('Your previous global config was renamed');
+        expect(stdoutData).to.include('Default global config will be recreated');
+      });
+    });
+  });
+
+  describe('getLoggedInUser', () => {
+    let globalConfigPath;
+
+    before(async () => {
+      globalConfigPath = path.join(os.homedir(), config.CONFIG_FILE_NAME);
+    });
+
+    after(async () => {
+      await fs.promises.unlink(globalConfigPath);
+    });
+
+    it('should return null if no userId', async () => {
+      const globalConfig = {
+        userId: null,
+      };
+      await fs.promises.writeFile(globalConfigPath, JSON.stringify(globalConfig, null, 2));
+      const result = config.getLoggedInUser();
+      expect(result).to.be.null;
+    });
+
+    it('should return null if no configuration for userId', async () => {
+      const globalConfig = {
+        userId: 1,
+      };
+      await fs.promises.writeFile(globalConfigPath, JSON.stringify(globalConfig, null, 2));
+      const result = config.getLoggedInUser();
+      expect(result).to.be.null;
+    });
+
+    it('should return null if username missing', async () => {
+      const globalConfig = {
+        userId: 1,
+        users: {
+          1: {
+            dashboard: {
+              accessKeys: ['firstkey', 'secondkey'],
+              idToken: 'idtoken',
+            },
+          },
+        },
+      };
+      await fs.promises.writeFile(globalConfigPath, JSON.stringify(globalConfig, null, 2));
+      const result = config.getLoggedInUser();
+      expect(result).to.be.null;
+    });
+
+    it('should return proper user object', async () => {
+      const globalConfig = {
+        userId: 1,
+        users: {
+          1: {
+            dashboard: {
+              username: 'firstUsername',
+              accessKeys: ['firstkey', 'secondkey'],
+              idToken: 'idtoken',
+            },
+          },
+        },
+      };
+      await fs.promises.writeFile(globalConfigPath, JSON.stringify(globalConfig, null, 2));
+      const result = config.getLoggedInUser();
+      expect(result).to.deep.equal({
+        idToken: 'idtoken',
+        accessKeys: ['firstkey', 'secondkey'],
+        username: 'firstUsername',
+        userId: 1,
+      });
+    });
   });
 });


### PR DESCRIPTION
Notifications tests had to be adjusted because they became nondeterministic - in some cases, the `lastShown` date for two notifications was the same and not the one that was expected was returned.

It introduces the following breaking changes:
- Removed `getGlobalConfig` from API
- removed support for all `rc`-discoverable files
- update not always modify only global config (if local is present, it's the one that will get updated)

Closes: #69 