### PR TITLE
feat: Add account-related methods

### DIFF
--- a/account.js
+++ b/account.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const configUtils = require('./config');
+const jwtDecode = require('jwt-decode');
+
+const logout = () => {
+  const loggedInUser = configUtils.getLoggedInUser();
+  const data = {
+    userId: null,
+  };
+
+  if (loggedInUser) {
+    data.users = {
+      [loggedInUser.userId]: {
+        dashboard: {
+          accessToken: null,
+          idToken: null,
+          expiresAt: null,
+          refreshToken: null,
+        },
+      },
+    };
+  }
+
+  configUtils.set(data);
+};
+
+const refreshToken = async (sdk) => {
+  const loggedInUser = configUtils.getLoggedInUser();
+
+  if (!loggedInUser || !loggedInUser.refreshToken || !loggedInUser.idToken) {
+    return;
+  }
+
+  // Skip refresh if token did not expire yet
+  const decoded = jwtDecode(loggedInUser.idToken);
+  if (Number(decoded.exp) * 1000 > Date.now()) {
+    return;
+  }
+
+  const tokens = await sdk.session.refreshToken(loggedInUser.refreshToken);
+
+  const data = {
+    users: {
+      [loggedInUser.userId]: {
+        dashboard: {
+          idToken: tokens.id_token,
+          accessToken: tokens.access_token,
+        },
+      },
+    },
+  };
+
+  configUtils.set(data);
+};
+
+module.exports = {
+  logout,
+  refreshToken,
+};

--- a/config.js
+++ b/config.js
@@ -198,6 +198,7 @@ function getLoggedInUser() {
     username: user.username,
     accessKeys: user.accessKeys,
     idToken: user.idToken,
+    refreshToken: user.refreshToken,
   };
 }
 

--- a/docs/account.md
+++ b/docs/account.md
@@ -1,0 +1,17 @@
+## Utilities related to user account
+
+User account related utilities that also interact with stored config file. Several methods depend on `sdk` parameter, which should be provided as an instance of `ServerlessSDK` from `@serverless/platform-client` library.
+
+```javascript
+const accountUtils = require('@serverless/utils/account);
+```
+
+Exposes following _async_ methods:
+
+### `logout()`
+
+Logs out currently logged in user. It ensures that changes are saved to config file.
+
+### `refreshToken(sdk)`
+
+Conditionally refreshes `idToken` for currently logged in user if needed. If `idToken` did not expire yet, it won't be refreshed.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "chalk": "^4.1.0",
     "inquirer": "^7.3.3",
     "js-yaml": "^4.0.0",
+    "jwt-decode": "^3.1.2",
     "lodash": "^4.17.20",
     "ncjsm": "^4.1.0",
     "type": "^2.1.0",
@@ -32,6 +33,7 @@
     "prettier": "^2.2.1",
     "process-utils": "^4.0.0",
     "sinon": "^9.2.4",
+    "sinon-chai": "^3.5.0",
     "standard-version": "^9.1.0",
     "timers-ext": "^0.1.7"
   },

--- a/test/account.js
+++ b/test/account.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const account = require('../account');
+const sinon = require('sinon');
+const config = require('../config');
+const chai = require('chai');
+
+chai.use(require('sinon-chai'));
+chai.use(require('chai-as-promised'));
+
+const { expect } = chai;
+
+const nonexipredJwt =
+  'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJTTFMiLCJpYXQiOjE2MTE3NDAzNTgsImV4cCI6MTk1ODgwOTE1OCwiYXVkIjoic2xzIiwic3ViIjoic2xzQHNscy5jb20ifQ.fy_DY4cWWADDREVYrSy3U5-p7cKT4evEOCjQtQJl9ww';
+const expiredJwt =
+  'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJTTFMiLCJpYXQiOjE1ODAxMTc5NTgsImV4cCI6MTU4MDExNzk1OCwiYXVkIjoic2xzIiwic3ViIjoic2xzQHNscy5jb20ifQ.s2xmT0NDxuhuIUo4A6Dzm_aM1vGZWnOxJRNEkoD6X4Q';
+const refreshedJwt =
+  'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJTTFMiLCJpYXQiOjE1ODAxMTc5NTgsImV4cCI6MTg5NTczNzE1OCwiYXVkIjoic2xzIiwic3ViIjoic2xzQHNscy5jb20ifQ.cEB3jMC6P2TDCkX7UR9uOOPLIPDl8D7F31i0ovkV67w';
+
+describe('account', () => {
+  describe('logout', () => {
+    it('works correctly when no logged in user', () => {
+      config.set('userId', null);
+      account.logout();
+      expect(config.get('userId')).to.be.null;
+    });
+
+    it('works correctly when userId set but no corresponding data for user', () => {
+      config.set('userId', 123);
+      account.logout();
+      expect(config.get('userId')).to.be.null;
+    });
+
+    it('works correctly with loggedInUser', () => {
+      const userId = 456;
+      config.set({
+        userId,
+        users: {
+          [userId]: {
+            dashboard: {
+              username: 'username',
+              accessToken: 'access-token',
+              idToken: 'id-token',
+              refreshToken: 'refresh-token',
+              expiresAt: '123',
+            },
+          },
+        },
+      });
+
+      account.logout();
+
+      expect(config.getLoggedInUser()).to.be.null;
+      const configAfterLogout = config.getConfig();
+      expect(configAfterLogout.userId).to.be.null;
+      expect(configAfterLogout.users[userId].dashboard).to.deep.equal({
+        accessToken: null,
+        expiresAt: null,
+        idToken: null,
+        username: 'username',
+        refreshToken: null,
+      });
+    });
+  });
+
+  describe('refreshToken', () => {
+    const sdkRefreshTokenStub = sinon
+      .stub()
+      .returns({ id_token: refreshedJwt, access_token: 'refreshed-access-token' });
+    const sdk = { session: { refreshToken: sdkRefreshTokenStub } };
+
+    beforeEach(() => {
+      sdkRefreshTokenStub.resetHistory();
+    });
+
+    it('skips refresh if no logged in user', async () => {
+      config.set('userId', null);
+      await account.refreshToken(sdk);
+      expect(sdkRefreshTokenStub).not.to.be.called;
+    });
+
+    it('skips refresh if token did not expire yet', async () => {
+      const userId = 456;
+      config.set({
+        userId,
+        users: {
+          [userId]: {
+            dashboard: {
+              username: 'username',
+              accessToken: 'access-token',
+              idToken: nonexipredJwt,
+              refreshToken: 'refresh-token',
+              expiresAt: '123',
+            },
+          },
+        },
+      });
+      await account.refreshToken(sdk);
+      expect(sdkRefreshTokenStub).not.to.be.called;
+    });
+
+    it('correcly refreshes expired token', async () => {
+      const userId = 456;
+      config.set({
+        userId,
+        users: {
+          [userId]: {
+            dashboard: {
+              username: 'username',
+              accessToken: 'access-token',
+              idToken: expiredJwt,
+              refreshToken: 'refresh-token',
+              expiresAt: '123',
+            },
+          },
+        },
+      });
+      await account.refreshToken(sdk);
+      expect(sdkRefreshTokenStub).to.be.calledWith('refresh-token');
+      expect(config.getLoggedInUser().idToken).to.equal(refreshedJwt);
+    });
+  });
+});

--- a/test/config.js
+++ b/test/config.js
@@ -642,8 +642,9 @@ describe('config', () => {
           1: {
             dashboard: {
               username: 'firstUsername',
-              accessKeys: ['firstkey', 'secondkey'],
+              accessKeys: { firstOrg: 'firstkey', secondOrg: 'secondkey' },
               idToken: 'idtoken',
+              refreshToken: 'refresh-token',
             },
           },
         },
@@ -652,9 +653,10 @@ describe('config', () => {
       const result = config.getLoggedInUser();
       expect(result).to.deep.equal({
         idToken: 'idtoken',
-        accessKeys: ['firstkey', 'secondkey'],
+        accessKeys: { firstOrg: 'firstkey', secondOrg: 'secondkey' },
         username: 'firstUsername',
         userId: 1,
+        refreshToken: 'refresh-token',
       });
     });
   });


### PR DESCRIPTION
Adds account-related methods as described in linked issue. 

I've made a decision to depend on injected `sdk` instance, which is supposed to be an instance of `ServerlessSDK` from `@serverless/platform-client` library. It is aimed to be temporary solution, which will be cleaned up when `components`, `enterprise-plugin` and `serverless` will be moved into one repository. 

Closes: #72 