### PR TITLE
Uses createRequire

### DIFF
--- a/inquirer/index.js
+++ b/inquirer/index.js
@@ -6,8 +6,13 @@ const { dirname } = require('path');
 const requireUncached = require('ncjsm/require-uncached');
 const resolve = require('ncjsm/resolve/sync');
 const chalk = require('chalk');
+const { createRequire } = require('module');
 
-const inquirersChalkPath = resolve(dirname(require.resolve('inquirer')), 'chalk').realPath;
+const inquirerPath = require.resolve('inquirer');
+
+const inquirersChalkPath = createRequire
+  ? createRequire(inquirerPath).resolve('chalk')
+  : resolve(dirname(inquirerPath), 'chalk').realPath;
 
 module.exports = requireUncached(inquirersChalkPath, () => {
   // Ensure distinct chalk instance for inquirer and hack it with altered styles


### PR DESCRIPTION
The documented [`createRequire`](https://nodejs.org/dist/latest-v14.x/docs/api/module.html#module_module_createrequire_filename) function is available since Node 12 and lets you resolve module on behalf of other modules - which I believe is why you used ncjsm here. Since it's part of the Node API, it's expected to work regardless how the project is installed.

Ports https://github.com/serverless/inquirer/pull/4.
Fixes https://github.com/serverless/inquirer/issues/3.