### PR TITLE
feat: Do not return `null` as analyticsUrl for CI=true

### DIFF
--- a/analytics-and-notfications-url.js
+++ b/analytics-and-notfications-url.js
@@ -5,11 +5,6 @@ if (process.env.SLS_ANALYTICS_URL) {
   return;
 }
 
-if (process.env.CI) {
-  module.exports = null;
-  return;
-}
-
 const isInChina = require('./is-in-china');
 
 module.exports = isInChina


### PR DESCRIPTION
We would like to record events from `CI` as well as we plan to introduce CI detection and enrich analytics events with that information

Note: The plan is to release it as a major version to avoid changing behavior for older versions which won't include information about `CI` 