### PR TITLE
feat: Add !merge YAML tag support

### DIFF
--- a/cloudformation-schema.js
+++ b/cloudformation-schema.js
@@ -3,6 +3,7 @@
 const yaml = require('js-yaml');
 const _ = require('lodash');
 
+// CloudFormation functions
 const functionNames = [
   'And',
   'Base64',
@@ -40,12 +41,65 @@ const yamlType = (name, kind) => {
   });
 };
 
+/**
+ * handleMergeTag implements the tag processing for the custom `!merge` tag that we
+ * are introducing to allow transparent merging of objects and arrays in the framework.
+ *
+ * When the provided data is a list of objects, the objects are shallowly merged: the
+ * objects are flattened together like `Object.assign({}, ...data)`. Unlike `Object.assign`,
+ * if there are key collisions in the provided list of objects, this will throw an exception
+ * rather than overwriting the duplicated keys.
+ *
+ * When the provided data is a list of arrays, the arrays are flattened and returned as
+ * a single array with all of the combined elements. There is no removal of duplicate
+ * items from the list.
+ *
+ * @param {Array} data
+ * @returns the merged result.
+ */
+const handleMergeTag = (data) => {
+  if (!Array.isArray(data)) {
+    throw new Error('!merge needs a sequence of values to merge');
+  }
+
+  if (data.every((item) => Array.isArray(item))) {
+    return _.flatten(data);
+  }
+
+  if (data.every((item) => typeof item === 'object' && !Array.isArray(item))) {
+    const keys = {};
+
+    data.forEach((item, index) => {
+      Object.keys(item).forEach((key) => {
+        if (keys[key] !== undefined) {
+          throw new Error(
+            `duplicate key \`${key}\` in !merge[${index}]; first seen in !merge[${keys[key]}]`
+          );
+        }
+        keys[key] = index;
+      });
+    });
+
+    return Object.assign({}, ...data);
+  }
+
+  throw new Error('!merge needs a sequence of arrays or objects to merge');
+};
+
 const createSchema = () => {
   const types = _.flatten(
     functionNames.map((functionName) =>
       ['mapping', 'scalar', 'sequence'].map((kind) => yamlType(functionName, kind))
     )
   );
+
+  types.push(
+    new yaml.Type('!merge', {
+      kind: 'sequence',
+      construct: handleMergeTag,
+    })
+  );
+
   return yaml.DEFAULT_SCHEMA.extend(types);
 };
 

--- a/docs/cloudformation-schema.md
+++ b/docs/cloudformation-schema.md
@@ -12,3 +12,13 @@ const cloudFormationSchema = require('@serverless/utils/cloudformationSchema');
 
 yaml.load(fs.readFileSync('serverless.yml', { schema: cloudformationSchema });
 ```
+
+## !merge tag
+
+This schema also defines the `!merge` tag, which takes a `sequence` of either objects or arrays.
+
+When the provided sequence is a list of arrays, the arrays are concatenated together to form a
+single array.
+
+When the provided sequence is a list of objects, the objects are merged into a single object.
+Duplicate keys will result in an error being thrown to avoid accidental overwriting.


### PR DESCRIPTION
This extends the YAML schema to support a `!merge` tag as described in serverless/serverless#8037:

### Example: merge objects

```yaml
provider:
  environment: !merge
    - FOO: value1
    - BAR: value2
```

results in:

```yaml
provider:
  environment:
    FOO: value1
    BAR: value2
```

which may seem less-than-thrilling but if you consider the case of

```yaml
provider:
  environment: !merge
    - ${file(stage-env.json)}
    - ${file(common-env.json)}
```

or:

```yaml
resources:
  Resources: !merge
    - ${file(resources1.yaml)}
    - ${file(resources2.yaml)}
```

it becomes more interesting.

🚨 This will throw an error if there are key collisions in the list of objects given to `!merge`; it will not simply overwrite the keys like what happens with `Object.assign({}, ...)`.

### Example: "merge" arrays

If `!merge` is given a list of arrays, it will do a shallow flattening of the provided arrays and return a list that is the equivalent of concatenating all of the lists together. There is no detection or removal of duplicate elements.

```yaml
resources:
  Resources:
    example:
      Type: AWS::S3::Bucket
      DependsOn: !merge
        - ["a", "b"]
        - ["c", "d"]
 ```

becomes

```yaml
resources:
  Resources:
    example:
      Type: AWS::S3::Bucket
      DependsOn:
        - "a"
        - "b"
        - "c"
        - "d"
```

which again is more interesting if you consider the opportunities for merging more complex content.