### PR TITLE
Remove `Serverless:` prefix from `inquirer`

### DIFF
--- a/inquirer/index.js
+++ b/inquirer/index.js
@@ -24,11 +24,11 @@ module.exports = requireUncached(inquirersChalkPath, () => {
     },
   });
 
-  // 'Serverless:' prefix
   const BasePrompt = require('inquirer/lib/prompts/base');
   const originalGetQuestion = BasePrompt.prototype.getQuestion;
   BasePrompt.prototype.getQuestion = function () {
-    this.opt.prefix = 'Serverless:';
+    // Here we want to override the default prefix which is equal to `chalk.green('?')`
+    this.opt.prefix = '';
     return originalGetQuestion.call(this);
   };
 


### PR DESCRIPTION
BREAKING CHANGE: Inquirer prompt will have no prefix instead of `Serverless:`
If you wish, to still use `Serverless:` prefix, override it on the client side.

Related to: https://github.com/serverless/serverless/issues/9367