### PR TITLE
Support disabling entity in `log` util

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -29,3 +29,7 @@ Log message with custom color
 ### `log(message, { entity: 'Custom' })`
 
 Log message with custom entity
+
+### `log(message, { entity: null })`
+
+Log message with disabled entity, outputs messages in form of `<formatted message>\n`

--- a/log.js
+++ b/log.js
@@ -10,5 +10,10 @@ module.exports = (message, options = {}) => {
   if (underline) print = print.underline;
   if (bold) print = print.bold;
 
-  process.stdout.write(`${entity}: ${print(message)}\n`);
+  // In order to support stripping entity prefix by passing "entity: null"
+  if (entity) {
+    process.stdout.write(`${entity}: ${print(message)}\n`);
+  } else {
+    process.stdout.write(`${print(message)}\n`);
+  }
 };

--- a/test/log.js
+++ b/test/log.js
@@ -13,7 +13,7 @@ describe('log', () => {
       () => log('basic message')
     );
     expect(stdoutData).to.have.string('basic message');
-    expect(stdoutData.startsWith('Serverless')).to.be.true;
+    expect(stdoutData.startsWith('Serverless: ')).to.be.true;
   });
 
   it('supports message with custom entity', () => {
@@ -22,8 +22,17 @@ describe('log', () => {
       (data) => (stdoutData += data),
       () => log('basic message', { entity: 'NotServerless' })
     );
-    expect(stdoutData.startsWith('NotServerless')).to.be.true;
+    expect(stdoutData.startsWith('NotServerless: ')).to.be.true;
     expect(stdoutData).to.have.string(chalk.yellow('basic message'));
+  });
+
+  it('supports message with disabled entity', () => {
+    let stdoutData = '';
+    overrideStdoutWrite(
+      (data) => (stdoutData += data),
+      () => log('basic message', { entity: null })
+    );
+    expect(stdoutData).to.equal(`${chalk.yellow('basic message')}\n`);
   });
 
   it('supports message with custom color', () => {
@@ -42,7 +51,7 @@ describe('log', () => {
       (data) => (stdoutData += data),
       () => log('basic message', { underline: true })
     );
-    expect(stdoutData.startsWith('Serverless')).to.be.true;
+    expect(stdoutData.startsWith('Serverless: ')).to.be.true;
     expect(stdoutData).to.have.string(chalk.yellow.underline('basic message'));
   });
 
@@ -52,7 +61,7 @@ describe('log', () => {
       (data) => (stdoutData += data),
       () => log('basic message', { bold: true })
     );
-    expect(stdoutData.startsWith('Serverless')).to.be.true;
+    expect(stdoutData.startsWith('Serverless: ')).to.be.true;
     expect(stdoutData).to.have.string(chalk.yellow.bold('basic message'));
   });
 });


### PR DESCRIPTION
Needed in order to allow customizing log in interactive CLI outputs, related to: https://github.com/serverless/serverless/issues/9367