### PR TITLE
Backend notifications: Introduce force display mode

### DIFF
--- a/docs/process-backend-notification-request.md
+++ b/docs/process-backend-notification-request.md
@@ -11,3 +11,9 @@ const notification = processBackendNotificationRequest(notifiations);
 
 if (notification) printNotifiation(notifications);
 ```
+
+## Notifications mode
+
+Notifications presentation mode can be tweaked depending on given environment needs.
+
+Check [Telemetry and notifications](https://www.serverless.com/framework/docs/telemetry#adjustingdisabling-notifications) documentation for details

--- a/process-backend-notification-request.js
+++ b/process-backend-notification-request.js
@@ -14,10 +14,17 @@ const logError = (message) => {
   process.stdout.write(`Notifications error: ${message}\n`);
 };
 
-const NOTIFICATIONS_MODE_OFF = '0';
-const NOTIFICATIONS_MODE_ONLY_OUTDATED_VERSION = '1';
-const NOTIFICATIONS_MODE_ON = '2';
-const NOTIFICATIONS_MODE_FORCE = '3';
+const NOTIFICATIONS_MODE_OFF = 'off';
+const NOTIFICATIONS_MODE_ONLY_OUTDATED_VERSION = 'upgrades-only';
+const NOTIFICATIONS_MODE_ON = 'on';
+const NOTIFICATIONS_MODE_FORCE = 'force';
+
+const oldNotationMap = [
+  NOTIFICATIONS_MODE_OFF,
+  NOTIFICATIONS_MODE_ONLY_OUTDATED_VERSION,
+  NOTIFICATIONS_MODE_ON,
+  NOTIFICATIONS_MODE_FORCE,
+];
 
 const ALLOWED_NOTIFICATIONS_MODES = new Set([
   NOTIFICATIONS_MODE_ON,
@@ -27,7 +34,9 @@ const ALLOWED_NOTIFICATIONS_MODES = new Set([
 ]);
 
 const getNotificationsMode = () => {
-  const modeFromEnv = process.env.SLS_NOTIFICATIONS_MODE;
+  const modeFromEnv =
+    oldNotationMap[Number(process.env.SLS_NOTIFICATIONS_MODE)] ||
+    process.env.SLS_NOTIFICATIONS_MODE;
 
   if (modeFromEnv && ALLOWED_NOTIFICATIONS_MODES.has(modeFromEnv)) return modeFromEnv;
 

--- a/test/process-backend-notification-request.js
+++ b/test/process-backend-notification-request.js
@@ -125,4 +125,22 @@ describe('process-backend-notification-request', () => {
 
     expect(notification.code).to.equal('CODE123');
   });
+
+  it('Should force not shown or oldest shown with  SLS_NOTIFICATIONS_MODE set to 3', async () => {
+    await overrideEnv({ variables: { SLS_NOTIFICATIONS_MODE: '3' } }, async () => {
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE24');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE12');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE6');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0A');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0B');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0C');
+
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE24');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE12');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE6');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0A');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0B');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0C');
+    });
+  });
 });

--- a/test/process-backend-notification-request.js
+++ b/test/process-backend-notification-request.js
@@ -102,7 +102,7 @@ describe('process-backend-notification-request', () => {
     expect(notification).to.be.null;
   });
 
-  it('Should only consider outdated version notifs if SLS_NOTIFICATIONS_MODE set to 1', async () => {
+  it('Should only consider outdated version notifications if SLS_NOTIFICATIONS_MODE set to 1', async () => {
     let notification;
     await overrideEnv({ variables: { SLS_NOTIFICATIONS_MODE: '1' } }, async () => {
       notification = await processTargetNotifications([
@@ -114,7 +114,7 @@ describe('process-backend-notification-request', () => {
     expect(notification.code).to.equal('OUTDATED_MINOR_VERSION');
   });
 
-  it('Should consider all notifs if SLS_NOTIFICATIONS_MODE set to 2', async () => {
+  it('Should consider all notifications if SLS_NOTIFICATIONS_MODE set to 2', async () => {
     let notification;
     await overrideEnv({ variables: { SLS_NOTIFICATIONS_MODE: '2' } }, async () => {
       notification = await processTargetNotifications([

--- a/test/process-backend-notification-request.js
+++ b/test/process-backend-notification-request.js
@@ -9,7 +9,7 @@ const processBackendNotificationRequest = proxyquire('../process-backend-notific
   'ci-info': { isCI: false },
 });
 
-const testOrderFixture = [
+const defaultFixture = [
   { code: 'CODE12', message: 'Some notification', visibilityInterval: 12 },
   { code: 'CODE0A', message: 'Some notification', visibilityInterval: 0 },
   { code: 'CODE6', message: 'Some notification', visibilityInterval: 6 },
@@ -62,18 +62,18 @@ describe('process-backend-notification-request', () => {
   });
 
   it('Should favor notification to be shown least frequently', async () => {
-    expect((await processTargetNotifications(testOrderFixture)).code).to.equal('CODE24');
-    expect((await processTargetNotifications(testOrderFixture)).code).to.equal('CODE12');
-    expect((await processTargetNotifications(testOrderFixture)).code).to.equal('CODE6');
+    expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE24');
+    expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE12');
+    expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE6');
   });
 
   it('If notification is to be shown always, favor one shown least recently', async () => {
-    expect((await processTargetNotifications(testOrderFixture)).code).to.equal('CODE0A');
-    expect((await processTargetNotifications(testOrderFixture)).code).to.equal('CODE0B');
-    expect((await processTargetNotifications(testOrderFixture)).code).to.equal('CODE0C');
-    expect((await processTargetNotifications(testOrderFixture)).code).to.equal('CODE0A');
-    expect((await processTargetNotifications(testOrderFixture)).code).to.equal('CODE0B');
-    expect((await processTargetNotifications(testOrderFixture)).code).to.equal('CODE0C');
+    expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0A');
+    expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0B');
+    expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0C');
+    expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0A');
+    expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0B');
+    expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0C');
   });
 
   it('Should ignore all notifications if SLS_NOTIFICATIONS_MODE set to 0', async () => {

--- a/test/process-backend-notification-request.js
+++ b/test/process-backend-notification-request.js
@@ -16,7 +16,7 @@ const testOrderFixture = [
   { code: 'CODE0B', message: 'Some notification', visibilityInterval: 0 },
   { code: 'CODE24', message: 'Some notification', visibilityInterval: 24 },
   { code: 'CODE0C', message: 'Some notification', visibilityInterval: 0 },
-].sort();
+];
 
 describe('process-backend-notification-request', () => {
   // Reason for enforcing time progress is that the test became flaky - in some situations two notifications

--- a/test/process-backend-notification-request.js
+++ b/test/process-backend-notification-request.js
@@ -18,14 +18,14 @@ const testOrderFixture = [
   { code: 'CODE0C', message: 'Some notification', visibilityInterval: 0 },
 ];
 
-describe('process-backend-notification-request', () => {
-  // Reason for enforcing time progress is that the test became flaky - in some situations two notifications
-  // had the same lastShown value in config
-  const validateNotificationAndEnsureClockProgress = async (notificationCode) => {
-    expect(processTargetNotifications(testOrderFixture).code).to.equal(notificationCode);
-    await wait(1);
-  };
+// Reason for enforcing time progress is that the test became flaky - in some situations two notifications
+// had the same lastShown value in config
+const validateNotificationAndEnsureClockProgress = async (notificationCode) => {
+  expect(processTargetNotifications(testOrderFixture).code).to.equal(notificationCode);
+  await wait(1);
+};
 
+describe('process-backend-notification-request', () => {
   it('Should ignore invalid input', () => {
     expect(processTargetNotifications()).to.equal(null);
     expect(


### PR DESCRIPTION
Introduce (`SLS_NOTIFICATIONS_MODE=3`) mode, with which notification as returned by backend is always shown to user (It's useful to test how backend resolves notifications in given service context).

Additionally
- Added more UX friendly notifications code notation (`off`, `upgrades-only`, `on`, `force`) maintaining support for old code
- Improved tests organization

Documentation update at https://github.com/serverless/serverless/pull/9755