### PR TITLE
Recognize continue prompts in history with `_continuation_`

### DIFF
--- a/inquirer/prompt-with-history.js
+++ b/inquirer/prompt-with-history.js
@@ -24,6 +24,10 @@ module.exports = async (options = {}) => {
       return answer;
     }
 
+    if (answer === '') {
+      return '_continuation_';
+    }
+
     if (type === 'list') {
       return '_user_choice_';
     }

--- a/test/inquirer/prompt-with-history.js
+++ b/test/inquirer/prompt-with-history.js
@@ -62,6 +62,25 @@ describe('inquirer/confirm', () => {
     expect(stepHistory.get('someQuestion')).to.have.property('finalizedAt');
   });
 
+  it('Should work and correctly report `_continuation_` for empty answers', async () => {
+    const stepHistory = new StepHistory();
+
+    configureInquirerStub(inquirer, {
+      input: { someQuestion: '' },
+    });
+
+    expect(
+      await inquirerPromptWithHistory({
+        message: 'Question?',
+        name: 'someQuestion',
+        stepHistory,
+      })
+    ).to.equal('');
+    expect(stepHistory.get('someQuestion').value).to.equal('_continuation_');
+    expect(stepHistory.get('someQuestion')).to.have.property('startedAt');
+    expect(stepHistory.get('someQuestion')).to.have.property('finalizedAt');
+  });
+
   it('Should work and report predefined select answers in history', async () => {
     const stepHistory = new StepHistory();
 


### PR DESCRIPTION
As discussed in: https://github.com/serverless/serverless/pull/9768