### PR TITLE
feat: Resolve notifications for each type separately

### DIFF
--- a/docs/process-backend-notification-request.md
+++ b/docs/process-backend-notification-request.md
@@ -1,15 +1,15 @@
 # processBackendNotificationRequest
 
-Out of all applicable notifications as returned by backend. Resolves one that applies mostly to user at given moment.
+Out of all applicable notifications as returned by backend, resolves one that applies mostly to user at given moment for each of notification types. Currently backend will return only two types of notifications: `promotional` and `update`.
 
 Logic depends purely on history of previously shown notifications.
 
 ```javascript
 const processBackendNotificationRequest = require('@serverless/utils/process-backend-notification-request');
 
-const notification = processBackendNotificationRequest(notifiations);
+const notifications = processBackendNotificationRequest(notifiations);
 
-if (notification) printNotifiation(notifications);
+printNotifiations(notifications);
 ```
 
 ## Notifications mode

--- a/test/process-backend-notification-request.js
+++ b/test/process-backend-notification-request.js
@@ -12,12 +12,12 @@ const processBackendNotificationRequest = proxyquire('../process-backend-notific
 });
 
 const defaultFixture = [
-  { code: 'CODE12', message: 'Some notification', visibilityInterval: 12 },
-  { code: 'CODE0A', message: 'Some notification', visibilityInterval: 0 },
-  { code: 'CODE6', message: 'Some notification', visibilityInterval: 6 },
-  { code: 'CODE0B', message: 'Some notification', visibilityInterval: 0 },
-  { code: 'CODE24', message: 'Some notification', visibilityInterval: 24 },
-  { code: 'CODE0C', message: 'Some notification', visibilityInterval: 0 },
+  { code: 'CODE12', message: 'Some notification', visibilityInterval: 12, type: 'promotional' },
+  { code: 'CODE0A', message: 'Some notification', visibilityInterval: 0, type: 'promotional' },
+  { code: 'CODE6', message: 'Some notification', visibilityInterval: 6, type: 'promotional' },
+  { code: 'CODE0B', message: 'Some notification', visibilityInterval: 0, type: 'promotional' },
+  { code: 'CODE24', message: 'Some notification', visibilityInterval: 24, type: 'promotional' },
+  { code: 'CODE0C', message: 'Some notification', visibilityInterval: 0, type: 'promotional' },
 ];
 
 // Reason for enforcing time progress is that the test became flaky - in some situations two notifications
@@ -34,7 +34,7 @@ describe('process-backend-notification-request', () => {
   afterEach(async () => fsp.unlink(configFileName));
 
   it('Should ignore invalid input', async () => {
-    expect(await processTargetNotifications()).to.equal(null);
+    expect(await processTargetNotifications()).to.deep.equal({});
     expect(
       await processTargetNotifications([
         null,
@@ -44,50 +44,68 @@ describe('process-backend-notification-request', () => {
         { message: 'FOO' },
         { code: 'CODE1' },
       ])
-    ).to.equal(null);
+    ).to.deep.equal({});
   });
 
   it('Should show not shown notification', async () => {
-    const notification = await processTargetNotifications([
-      { code: 'CODE1', message: 'Some notification #1' },
-      { code: 'CODE2', message: 'Some notification #2' },
+    const notifications = await processTargetNotifications([
+      { code: 'CODE1', message: 'Some notification #1', type: 'promotional' },
+      { code: 'CODE2', message: 'Some notification #2', type: 'promotional' },
     ]);
 
-    expect(notification.code).to.equal('CODE1');
+    expect(notifications.promotional.code).to.equal('CODE1');
   });
 
   it('Should skip shown notification', async () => {
     await processTargetNotifications([
-      { code: 'CODE1', message: 'Some notification #1' },
-      { code: 'CODE2', message: 'Some notification #2' },
+      { code: 'CODE1', message: 'Some notification #1', type: 'promotional' },
+      { code: 'CODE2', message: 'Some notification #2', type: 'promotional' },
     ]);
     const notification = await processTargetNotifications([
-      { code: 'CODE1', message: 'Some notification #1' },
-      { code: 'CODE2', message: 'Some notification #2' },
+      { code: 'CODE1', message: 'Some notification #1', type: 'promotional' },
+      { code: 'CODE2', message: 'Some notification #2', type: 'promotional' },
     ]);
 
-    expect(notification.code).to.equal('CODE2');
+    expect(notification.promotional.code).to.equal('CODE2');
+  });
+
+  it('Should skip shown notification correctly with multiple types', async () => {
+    await processTargetNotifications([
+      { code: 'CODE1', message: 'Some notification #1', type: 'promotional' },
+      { code: 'CODE2', message: 'Some notification #2', type: 'promotional' },
+      { code: 'CODE3', message: 'Some notification #3', type: 'other' },
+      { code: 'CODE4', message: 'Some notification #3', type: 'other' },
+    ]);
+    const notification = await processTargetNotifications([
+      { code: 'CODE1', message: 'Some notification #1', type: 'promotional' },
+      { code: 'CODE2', message: 'Some notification #2', type: 'promotional' },
+      { code: 'CODE3', message: 'Some notification #3', type: 'other' },
+      { code: 'CODE4', message: 'Some notification #3', type: 'other' },
+    ]);
+
+    expect(notification.promotional.code).to.equal('CODE2');
+    expect(notification.other.code).to.equal('CODE4');
   });
 
   it('Should favor notification to be shown least frequently', async () => {
-    expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE24');
-    expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE12');
-    expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE6');
-    expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0A');
+    expect((await processTargetNotifications(defaultFixture)).promotional.code).to.equal('CODE24');
+    expect((await processTargetNotifications(defaultFixture)).promotional.code).to.equal('CODE12');
+    expect((await processTargetNotifications(defaultFixture)).promotional.code).to.equal('CODE6');
+    expect((await processTargetNotifications(defaultFixture)).promotional.code).to.equal('CODE0A');
   });
 
   it('If notification is to be shown always, favor one shown least recently', async () => {
     const fixture = [
-      { code: 'CODE0A', message: 'Some notification', visibilityInterval: 0 },
-      { code: 'CODE0B', message: 'Some notification', visibilityInterval: 0 },
-      { code: 'CODE0C', message: 'Some notification', visibilityInterval: 0 },
+      { code: 'CODE0A', message: 'Some notification', visibilityInterval: 0, type: 'promotional' },
+      { code: 'CODE0B', message: 'Some notification', visibilityInterval: 0, type: 'promotional' },
+      { code: 'CODE0C', message: 'Some notification', visibilityInterval: 0, type: 'promotional' },
     ];
-    expect((await processTargetNotifications(fixture)).code).to.equal('CODE0A');
-    expect((await processTargetNotifications(fixture)).code).to.equal('CODE0B');
-    expect((await processTargetNotifications(fixture)).code).to.equal('CODE0C');
-    expect((await processTargetNotifications(fixture)).code).to.equal('CODE0A');
-    expect((await processTargetNotifications(fixture)).code).to.equal('CODE0B');
-    expect((await processTargetNotifications(fixture)).code).to.equal('CODE0C');
+    expect((await processTargetNotifications(fixture)).promotional.code).to.equal('CODE0A');
+    expect((await processTargetNotifications(fixture)).promotional.code).to.equal('CODE0B');
+    expect((await processTargetNotifications(fixture)).promotional.code).to.equal('CODE0C');
+    expect((await processTargetNotifications(fixture)).promotional.code).to.equal('CODE0A');
+    expect((await processTargetNotifications(fixture)).promotional.code).to.equal('CODE0B');
+    expect((await processTargetNotifications(fixture)).promotional.code).to.equal('CODE0C');
   });
 
   describe('Notifications mode', () => {
@@ -95,65 +113,90 @@ describe('process-backend-notification-request', () => {
       it(`Should ignore all notifications if SLS_NOTIFICATIONS_MODE set to ${map(
         'off'
       )}`, async () => {
-        let notification;
+        let notifications;
         await overrideEnv({ variables: { SLS_NOTIFICATIONS_MODE: map('off') } }, async () => {
-          notification = await processTargetNotifications([
-            { code: 'CODE123', message: 'Some notification #1' },
-            { code: 'CODE456', message: 'Some notification #2' },
+          notifications = await processTargetNotifications([
+            { code: 'CODE123', message: 'Some notification #1', type: 'promotional' },
+            { code: 'CODE456', message: 'Some notification #2', type: 'anothertype' },
           ]);
         });
 
-        expect(notification).to.be.null;
+        expect(notifications).to.deep.equal({});
       });
 
       it(`Should only consider outdated version notifications if SLS_NOTIFICATIONS_MODE set to ${map(
         'upgrades-only'
       )}`, async () => {
-        let notification;
+        let notifications;
         await overrideEnv(
           { variables: { SLS_NOTIFICATIONS_MODE: map('upgrades-only') } },
           async () => {
-            notification = await processTargetNotifications([
-              { code: 'CODE456', message: 'Some notification' },
-              { code: 'OUTDATED_MINOR_VERSION', message: 'outdated' },
+            notifications = await processTargetNotifications([
+              { code: 'CODE456', message: 'Some notification', type: 'promotional' },
+              { code: 'OUTDATED_MINOR_VERSION', message: 'outdated', type: 'update' },
             ]);
           }
         );
 
-        expect(notification.code).to.equal('OUTDATED_MINOR_VERSION');
+        expect(notifications.promotional).to.be.undefined;
+        expect(notifications.update.code).to.equal('OUTDATED_MINOR_VERSION');
       });
 
       it(`Should consider all notifications if SLS_NOTIFICATIONS_MODE set to ${map(
         'on'
       )}`, async () => {
-        let notification;
+        let notifications;
         await overrideEnv({ variables: { SLS_NOTIFICATIONS_MODE: map('on') } }, async () => {
-          notification = await processTargetNotifications([
-            { code: 'CODE123', message: 'Some notification #1' },
-            { code: 'CODE456', message: 'Some notification #2' },
+          notifications = await processTargetNotifications([
+            { code: 'CODE123', message: 'Some notification #1', type: 'promotional' },
+            { code: 'CODE456', message: 'Some notification #2', type: 'promotional' },
           ]);
         });
 
-        expect(notification.code).to.equal('CODE123');
+        expect(notifications.promotional.code).to.equal('CODE123');
       });
 
       it(`Should force not shown or oldest shown with  SLS_NOTIFICATIONS_MODE set to ${map(
         'force'
       )}`, async () => {
         await overrideEnv({ variables: { SLS_NOTIFICATIONS_MODE: map('force') } }, async () => {
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE24');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE12');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE6');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0A');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0B');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0C');
+          expect((await processTargetNotifications(defaultFixture)).promotional.code).to.equal(
+            'CODE24'
+          );
+          expect((await processTargetNotifications(defaultFixture)).promotional.code).to.equal(
+            'CODE12'
+          );
+          expect((await processTargetNotifications(defaultFixture)).promotional.code).to.equal(
+            'CODE6'
+          );
+          expect((await processTargetNotifications(defaultFixture)).promotional.code).to.equal(
+            'CODE0A'
+          );
+          expect((await processTargetNotifications(defaultFixture)).promotional.code).to.equal(
+            'CODE0B'
+          );
+          expect((await processTargetNotifications(defaultFixture)).promotional.code).to.equal(
+            'CODE0C'
+          );
 
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE24');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE12');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE6');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0A');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0B');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0C');
+          expect((await processTargetNotifications(defaultFixture)).promotional.code).to.equal(
+            'CODE24'
+          );
+          expect((await processTargetNotifications(defaultFixture)).promotional.code).to.equal(
+            'CODE12'
+          );
+          expect((await processTargetNotifications(defaultFixture)).promotional.code).to.equal(
+            'CODE6'
+          );
+          expect((await processTargetNotifications(defaultFixture)).promotional.code).to.equal(
+            'CODE0A'
+          );
+          expect((await processTargetNotifications(defaultFixture)).promotional.code).to.equal(
+            'CODE0B'
+          );
+          expect((await processTargetNotifications(defaultFixture)).promotional.code).to.equal(
+            'CODE0C'
+          );
         });
       });
     };


### PR DESCRIPTION
BREAKING CHANGE: `processBackendNotificationRequest` no longer resolves to
single notification but rather to an object that maps notification type to
resolved notification.