### PR TITLE
Introduce `notifications` module

### DIFF
--- a/docs/get-notifications-mode.md
+++ b/docs/get-notifications-mode.md
@@ -1,0 +1,7 @@
+## `getNotificationsMode()`
+
+```javascript
+const getNotificationsMode = require('@serverless/utils/telemetry');
+```
+
+Resolves notification mode based on `SLS_NOTIFICATION_MODE` environment variable setting. When that setting is not available, it returns `NOTIFICATIONS_MODE_ON` or `NOTIFICATIONS_MODE_ONLY_OUTDATED_VERSION` in cases where function is executed in context of CI environment as identified by `ci-info` library.

--- a/get-notifications-mode.js
+++ b/get-notifications-mode.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const ci = require('ci-info');
+
+const NOTIFICATIONS_MODE_OFF = 'off';
+const NOTIFICATIONS_MODE_ONLY_OUTDATED_VERSION = 'upgrades-only';
+const NOTIFICATIONS_MODE_ON = 'on';
+const NOTIFICATIONS_MODE_FORCE = 'force';
+
+const oldNotationMap = [
+  NOTIFICATIONS_MODE_OFF,
+  NOTIFICATIONS_MODE_ONLY_OUTDATED_VERSION,
+  NOTIFICATIONS_MODE_ON,
+  NOTIFICATIONS_MODE_FORCE,
+];
+
+const ALLOWED_NOTIFICATIONS_MODES = new Set([
+  NOTIFICATIONS_MODE_ON,
+  NOTIFICATIONS_MODE_ONLY_OUTDATED_VERSION,
+  NOTIFICATIONS_MODE_OFF,
+  NOTIFICATIONS_MODE_FORCE,
+]);
+
+const getNotificationsMode = () => {
+  const modeFromEnv =
+    oldNotationMap[Number(process.env.SLS_NOTIFICATIONS_MODE)] ||
+    process.env.SLS_NOTIFICATIONS_MODE;
+
+  if (modeFromEnv && ALLOWED_NOTIFICATIONS_MODES.has(modeFromEnv)) return modeFromEnv;
+
+  if (ci.isCI) return NOTIFICATIONS_MODE_ONLY_OUTDATED_VERSION;
+
+  return NOTIFICATIONS_MODE_ON;
+};
+
+module.exports = getNotificationsMode;

--- a/test/get-notifications-mode.js
+++ b/test/get-notifications-mode.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const { expect } = require('chai');
+const proxyquire = require('proxyquire');
+const overrideEnv = require('process-utils/override-env');
+
+const getNotificationsMode = proxyquire('../get-notifications-mode', {
+  'ci-info': { isCI: false },
+});
+
+describe('get-notifications-mode', () => {
+  it('for SLS_NOTIFICATIONS_MODE set to `on`', () => {
+    let notificationMode;
+    overrideEnv({ variables: { SLS_NOTIFICATIONS_MODE: 'on' } }, () => {
+      notificationMode = getNotificationsMode();
+    });
+    expect(notificationMode).to.equal('on');
+  });
+
+  it('for SLS_NOTIFICATIONS_MODE set to `2`', () => {
+    let notificationMode;
+    overrideEnv({ variables: { SLS_NOTIFICATIONS_MODE: '2' } }, () => {
+      notificationMode = getNotificationsMode();
+    });
+    expect(notificationMode).to.equal('on');
+  });
+
+  it('for SLS_NOTIFICATIONS_MODE set to `upgrades-only`', () => {
+    let notificationMode;
+    overrideEnv({ variables: { SLS_NOTIFICATIONS_MODE: 'upgrades-only' } }, () => {
+      notificationMode = getNotificationsMode();
+    });
+    expect(notificationMode).to.equal('upgrades-only');
+  });
+
+  it('for SLS_NOTIFICATIONS_MODE set to `1`', () => {
+    let notificationMode;
+    overrideEnv({ variables: { SLS_NOTIFICATIONS_MODE: '1' } }, () => {
+      notificationMode = getNotificationsMode();
+    });
+    expect(notificationMode).to.equal('upgrades-only');
+  });
+
+  it('for SLS_NOTIFICATIONS_MODE set to `off`', () => {
+    let notificationMode;
+    overrideEnv({ variables: { SLS_NOTIFICATIONS_MODE: 'off' } }, () => {
+      notificationMode = getNotificationsMode();
+    });
+    expect(notificationMode).to.equal('off');
+  });
+
+  it('for SLS_NOTIFICATIONS_MODE set to `0`', () => {
+    let notificationMode;
+    overrideEnv({ variables: { SLS_NOTIFICATIONS_MODE: '0' } }, () => {
+      notificationMode = getNotificationsMode();
+    });
+    expect(notificationMode).to.equal('off');
+  });
+
+  it('for SLS_NOTIFICATIONS_MODE set to `force`', () => {
+    let notificationMode;
+    overrideEnv({ variables: { SLS_NOTIFICATIONS_MODE: 'force' } }, () => {
+      notificationMode = getNotificationsMode();
+    });
+    expect(notificationMode).to.equal('force');
+  });
+
+  it('for SLS_NOTIFICATIONS_MODE set to `3`', () => {
+    let notificationMode;
+    overrideEnv({ variables: { SLS_NOTIFICATIONS_MODE: '3' } }, () => {
+      notificationMode = getNotificationsMode();
+    });
+    expect(notificationMode).to.equal('force');
+  });
+
+  it('for SLS_NOTIFICATIONS_MODE set to invalid value', () => {
+    let notificationMode;
+    overrideEnv({ variables: { SLS_NOTIFICATIONS_MODE: 'invalid' } }, () => {
+      notificationMode = getNotificationsMode();
+    });
+    expect(notificationMode).to.equal('on');
+  });
+
+  it('for SLS_NOTIFICATIONS_MODE not set', () => {
+    let notificationMode;
+    overrideEnv({}, () => {
+      notificationMode = getNotificationsMode();
+    });
+    expect(notificationMode).to.equal('on');
+  });
+});

--- a/test/process-backend-notification-request.js
+++ b/test/process-backend-notification-request.js
@@ -1,14 +1,17 @@
 'use strict';
 
 const { expect } = require('chai');
-const overrideEnv = require('process-utils/override-env');
 const fsp = require('fs').promises;
 const wait = require('timers-ext/promise/sleep');
 const proxyquire = require('proxyquire');
 const configFileName = require('../config').CONFIG_FILE_NAME;
 
+const sinon = require('sinon');
+
+const getNotificationsModeStub = sinon.stub();
+
 const processBackendNotificationRequest = proxyquire('../process-backend-notification-request', {
-  'ci-info': { isCI: false },
+  './get-notifications-mode': getNotificationsModeStub,
 });
 
 const defaultFixture = [
@@ -91,76 +94,51 @@ describe('process-backend-notification-request', () => {
   });
 
   describe('Notifications mode', () => {
-    const suite = (map) => {
-      it(`Should ignore all notifications if SLS_NOTIFICATIONS_MODE set to ${map(
-        'off'
-      )}`, async () => {
-        let notification;
-        await overrideEnv({ variables: { SLS_NOTIFICATIONS_MODE: map('off') } }, async () => {
-          notification = await processTargetNotifications([
-            { code: 'CODE123', message: 'Some notification #1' },
-            { code: 'CODE456', message: 'Some notification #2' },
-          ]);
-        });
+    it("Should ignore all notifications if notification mode set to 'off'", async () => {
+      getNotificationsModeStub.returns('off');
+      const notification = await processTargetNotifications([
+        { code: 'CODE123', message: 'Some notification #1' },
+        { code: 'CODE456', message: 'Some notification #2' },
+      ]);
 
-        expect(notification).to.be.null;
-      });
+      expect(notification).to.be.null;
+    });
 
-      it(`Should only consider outdated version notifications if SLS_NOTIFICATIONS_MODE set to ${map(
-        'upgrades-only'
-      )}`, async () => {
-        let notification;
-        await overrideEnv(
-          { variables: { SLS_NOTIFICATIONS_MODE: map('upgrades-only') } },
-          async () => {
-            notification = await processTargetNotifications([
-              { code: 'CODE456', message: 'Some notification' },
-              { code: 'OUTDATED_MINOR_VERSION', message: 'outdated' },
-            ]);
-          }
-        );
+    it("Should only consider outdated version notifications if notifications mode set to 'upgrades-only'", async () => {
+      getNotificationsModeStub.returns('upgrades-only');
+      const notification = await processTargetNotifications([
+        { code: 'CODE456', message: 'Some notification' },
+        { code: 'OUTDATED_MINOR_VERSION', message: 'outdated' },
+      ]);
 
-        expect(notification.code).to.equal('OUTDATED_MINOR_VERSION');
-      });
+      expect(notification.code).to.equal('OUTDATED_MINOR_VERSION');
+    });
 
-      it(`Should consider all notifications if SLS_NOTIFICATIONS_MODE set to ${map(
-        'on'
-      )}`, async () => {
-        let notification;
-        await overrideEnv({ variables: { SLS_NOTIFICATIONS_MODE: map('on') } }, async () => {
-          notification = await processTargetNotifications([
-            { code: 'CODE123', message: 'Some notification #1' },
-            { code: 'CODE456', message: 'Some notification #2' },
-          ]);
-        });
+    it("Should consider all notifications if notifications mode set to 'on'", async () => {
+      getNotificationsModeStub.returns('on');
+      const notification = await processTargetNotifications([
+        { code: 'CODE123', message: 'Some notification #1' },
+        { code: 'CODE456', message: 'Some notification #2' },
+      ]);
 
-        expect(notification.code).to.equal('CODE123');
-      });
+      expect(notification.code).to.equal('CODE123');
+    });
 
-      it(`Should force not shown or oldest shown with  SLS_NOTIFICATIONS_MODE set to ${map(
-        'force'
-      )}`, async () => {
-        await overrideEnv({ variables: { SLS_NOTIFICATIONS_MODE: map('force') } }, async () => {
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE24');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE12');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE6');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0A');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0B');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0C');
+    it("Should force not shown or oldest shown with notifications mode  set to 'force'", async () => {
+      getNotificationsModeStub.returns('force');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE24');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE12');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE6');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0A');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0B');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0C');
 
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE24');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE12');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE6');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0A');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0B');
-          expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0C');
-        });
-      });
-    };
-
-    suite((mode) => mode);
-
-    const oldNotationMap = { 'off': '0', 'upgrades-only': '1', 'on': '2', 'force': '3' };
-    suite((mode) => oldNotationMap[mode]);
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE24');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE12');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE6');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0A');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0B');
+      expect((await processTargetNotifications(defaultFixture)).code).to.equal('CODE0C');
+    });
   });
 });


### PR DESCRIPTION
Introduce separate `notifications` utils module in order to reuse `getNotificationsMode` method in Framework's telemetry (to report configured notifications mode) - related Framework PR: https://github.com/serverless/serverless/pull/9851