### PR TITLE
Log: `writeText` interface

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -83,3 +83,25 @@ It's the reason below interface was introduced, it should be used as last resort
 
 - `logLevelIndex` - Index of used log level (An array index from [levels](https://github.com/medikoo/log/blob/master/levels.json) list)
 - `isVerboseMode` - Weather we're in verbose mode or not (verbose mode is assumed if log level is set to _info_ or _debug_)
+
+### `writeText` Interface to write final outcome of the command
+
+_Note this part of an API is still experimental and subject to changes (not advertised to be used by external plugins)_
+
+Function through which output as returned by command should be written.
+
+It's not about any progress notifications but about substantial output as expected to be eventually returned by the command, e.g. `sls print` returns content of service configuration, `sls invoke` returns result as returned by invoked lambda, `sls deploy` returns generated (or updated) deployment outputs.
+
+This function by default is no-op. Main module of a process is expected to override it if intention is to write the output to the console (or other mean, depending on the environment)
+
+```javascript
+const { writeText } = require('@serverless/utils/log');
+
+writeText('Command result');
+
+// Multiline results can be pased with different text tokens (each will be presented on new line)
+writeText('Command multiline result', 'Second line', 'Third line');
+
+// Lines of texts can also injected with arrays (they're recursively flattened)
+writeText(['Command multiline result', 'Second line', 'Third line']);
+```

--- a/lib/log/join-text-tokens.js
+++ b/lib/log/join-text-tokens.js
@@ -1,0 +1,11 @@
+// Dedicated to join text tokens as passed to `writeText` and `progress.update`
+
+'use strict';
+
+const ensureString = require('type/string/ensure');
+const _ = require('lodash');
+
+module.exports = (...textTokens) =>
+  `${_.flattenDeep(textTokens)
+    .map((textToken) => ensureString(textToken, { isOptional: true, name: 'textToken' }) || '')
+    .join('\n')}\n`;

--- a/log.js
+++ b/log.js
@@ -45,3 +45,8 @@ Object.defineProperty(module.exports, 'isVerboseMode', {
   get: () => module.exports.logLevelIndex > logLevels.indexOf('notice'),
   enumerable: true,
 });
+
+// eslint-disable-next-line no-unused-vars
+module.exports.writeText = (text, ...textTokens) => {
+  // Intentionally no-op by default, overriden with writing logic in main module of a process
+};

--- a/test/lib/log/join-test-tokens.js
+++ b/test/lib/log/join-test-tokens.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const { expect } = require('chai');
+const joinTextTokens = require('../../../lib/log/join-text-tokens');
+
+describe('lib/log/join-text-tokens.js', () => {
+  it('should add new line at the of text', () => {
+    expect(joinTextTokens('foo bar')).to.equal('foo bar\n');
+  });
+  it('should join separate text tokens into multiline text', () => {
+    expect(joinTextTokens('foo', 'bar', 'other')).to.equal('foo\nbar\nother\n');
+  });
+  it('should resolve text tokens from input arrays recursively', () => {
+    expect(joinTextTokens('foo', ['bar', 'other', ['lorem', 'ipsum'], 'elo'], 'final')).to.equal(
+      'foo\nbar\nother\nlorem\nipsum\nelo\nfinal\n'
+    );
+  });
+  it('should treat `null` and `undefined` values as empty stirngs', () => {
+    expect(joinTextTokens('foo', null, 'bar', undefined, 'other')).to.equal(
+      'foo\n\nbar\n\nother\n'
+    );
+  });
+});

--- a/test/log.js
+++ b/test/log.js
@@ -158,4 +158,11 @@ describe('log', () => {
       expect(typeof log.isVerboseMode).to.equal('boolean');
     });
   });
+
+  describe('`writeText`', () => {
+    it('should export function', () => {
+      expect(typeof log.writeText).to.equal('function');
+      expect(log.writeText.length).to.equal(1);
+    });
+  });
 });


### PR DESCRIPTION
Addresses serverless/serverless#9860

Initially intention was to setup output registry as an event emitter (it's how e.g. event message logger internally works), still I think in this case we don't need to go that far (there's no viable use case where there can be two very different consumers of the output), hence I simply constructed it as function to be overridden with writing logic