### PR TITLE
Log: Plugin dedicated log & output writing interface

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -123,3 +123,9 @@ Write progress update on given item. Each update will overwrite previous update.
 ##### `remove()`
 
 Clear operation from progress bar (calling it means that processing of it ended)
+
+### `getPluginWriters(pluginName)` Get log & output writing functions dedicated for external plugins
+
+_Note this part of an API is still experimental and subject to changes (not advertised to be used by external plugins)_
+
+Returns `{ log, writeText, progress }` interface, same as one documented above, but dedicated to be used in context of external (named via `pluginName`) plugins. Calling function again, with same plugin name, will return previously created interface.

--- a/lib/log/get-output-reporter.js
+++ b/lib/log/get-output-reporter.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const outputEmitter = require('event-emitter')();
+const memoizee = require('memoizee');
+
+module.exports = memoizee(
+  (namespace) => {
+    return {
+      get: memoizee(
+        (mode) =>
+          (text, ...textTokens) => {
+            outputEmitter.emit('write', {
+              namespace,
+              mode,
+              textTokens: [text, ...textTokens],
+            });
+          },
+        { primitive: true }
+      ),
+    };
+  },
+  { primitive: true }
+);
+
+module.exports.emitter = outputEmitter;

--- a/lib/log/get-progress-reporter.js
+++ b/lib/log/get-progress-reporter.js
@@ -11,12 +11,11 @@ module.exports = memoizee(
       get: memoizee(
         (name) => {
           name = ensureString(name, { name: 'name' });
-          const id = `${namespace}:${name}`;
           const progress = {
             namespace,
             name,
             remove: () => {
-              progressEmitter.emit('remove', { id });
+              progressEmitter.emit('remove', { namespace, name });
             },
           };
           const levelsMeta = [
@@ -26,7 +25,8 @@ module.exports = memoizee(
           for (const { levelName, levelIndex } of levelsMeta) {
             progress[levelName] = (text, ...textTokens) => {
               progressEmitter.emit('update', {
-                id,
+                namespace,
+                name,
                 level: levelName,
                 levelIndex,
                 textTokens: [text, ...textTokens],
@@ -35,6 +35,7 @@ module.exports = memoizee(
           }
           return progress;
         },
+        namespace,
         { primitive: true }
       ),
     };

--- a/log.js
+++ b/log.js
@@ -3,6 +3,7 @@
 const chalk = require('chalk');
 const log = require('log').get('serverless');
 const logLevels = require('log/levels');
+const getOutputReporter = require('./lib/log/get-output-reporter');
 const getProgressReporter = require('./lib/log/get-progress-reporter');
 
 // Legacy interface, of which usage is scheduled to be replaced by modern one
@@ -47,9 +48,6 @@ Object.defineProperty(module.exports, 'isVerboseMode', {
   enumerable: true,
 });
 
-// eslint-disable-next-line no-unused-vars
-module.exports.writeText = (text, ...textTokens) => {
-  // Intentionally no-op by default, overriden with writing logic in main module of a process
-};
+module.exports.writeText = getOutputReporter('serverless').get('text');
 
 module.exports.progress = getProgressReporter('serverless');

--- a/test/lib/log/get-output-reporter.js
+++ b/test/lib/log/get-output-reporter.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const allOff = require('event-emitter/all-off');
+const getOutputReporter = require('../../../lib/log/get-output-reporter');
+
+const emitter = getOutputReporter.emitter;
+
+describe('lib/log/get-output-reporter.js', () => {
+  let events;
+
+  beforeEach(() => {
+    events = [];
+    emitter.on('write', (event) => events.push(event));
+  });
+  afterEach(() => {
+    allOff(emitter);
+  });
+
+  it('should return output intances factory', () => {
+    expect(typeof getOutputReporter('test').get('test')).to.equal('function');
+  });
+
+  it('should return same output reporter instance for same namespace', () => {
+    expect(getOutputReporter('test')).to.equal(getOutputReporter('test'));
+  });
+
+  it('should return same writer instance for same name', () => {
+    expect(getOutputReporter('test').get('test')).to.equal(getOutputReporter('test').get('test'));
+  });
+
+  it('should emit write events', () => {
+    const writeOutput = getOutputReporter('test').get('mode');
+    writeOutput('#1', 'other');
+    writeOutput('#2', 'another');
+    expect(events).to.deep.equal([
+      { namespace: 'test', mode: 'mode', textTokens: ['#1', 'other'] },
+      { namespace: 'test', mode: 'mode', textTokens: ['#2', 'another'] },
+    ]);
+  });
+});

--- a/test/lib/log/get-progress-reporter.js
+++ b/test/lib/log/get-progress-reporter.js
@@ -7,7 +7,7 @@ const getProgressReporter = require('../../../lib/log/get-progress-reporter');
 
 const emitter = getProgressReporter.emitter;
 
-describe('lib/log/progress.js', () => {
+describe('lib/log/get-progress-reporter.js', () => {
   let events;
 
   beforeEach(() => {

--- a/test/lib/log/get-progress-reporter.js
+++ b/test/lib/log/get-progress-reporter.js
@@ -40,10 +40,22 @@ describe('lib/log/get-progress-reporter.js', () => {
     progress.notice('#2');
     progress.info('#2');
     expect(events).to.deep.equal([
-      ['update', { id: 'test:upload', level: 'notice', levelIndex: 2, textTokens: ['#1'] }],
-      ['update', { id: 'test:upload', level: 'info', levelIndex: 3, textTokens: ['#1'] }],
-      ['update', { id: 'test:upload', level: 'notice', levelIndex: 2, textTokens: ['#2'] }],
-      ['update', { id: 'test:upload', level: 'info', levelIndex: 3, textTokens: ['#2'] }],
+      [
+        'update',
+        { namespace: 'test', name: 'upload', level: 'notice', levelIndex: 2, textTokens: ['#1'] },
+      ],
+      [
+        'update',
+        { namespace: 'test', name: 'upload', level: 'info', levelIndex: 3, textTokens: ['#1'] },
+      ],
+      [
+        'update',
+        { namespace: 'test', name: 'upload', level: 'notice', levelIndex: 2, textTokens: ['#2'] },
+      ],
+      [
+        'update',
+        { namespace: 'test', name: 'upload', level: 'info', levelIndex: 3, textTokens: ['#2'] },
+      ],
     ]);
   });
 
@@ -58,11 +70,38 @@ describe('lib/log/get-progress-reporter.js', () => {
     progress3.notice('#3-1');
 
     expect(events).to.deep.equal([
-      ['update', { id: 'test:upload', level: 'notice', levelIndex: 2, textTokens: ['#1-1'] }],
-      ['update', { id: 'other:upload', level: 'notice', levelIndex: 2, textTokens: ['#2-1'] }],
-      ['update', { id: 'test:upload', level: 'info', levelIndex: 3, textTokens: ['#1-1'] }],
-      ['update', { id: 'other:upload', level: 'info', levelIndex: 3, textTokens: ['#2-1'] }],
-      ['update', { id: 'test:package', level: 'notice', levelIndex: 2, textTokens: ['#3-1'] }],
+      [
+        'update',
+        { namespace: 'test', name: 'upload', level: 'notice', levelIndex: 2, textTokens: ['#1-1'] },
+      ],
+      [
+        'update',
+        {
+          namespace: 'other',
+          name: 'upload',
+          level: 'notice',
+          levelIndex: 2,
+          textTokens: ['#2-1'],
+        },
+      ],
+      [
+        'update',
+        { namespace: 'test', name: 'upload', level: 'info', levelIndex: 3, textTokens: ['#1-1'] },
+      ],
+      [
+        'update',
+        { namespace: 'other', name: 'upload', level: 'info', levelIndex: 3, textTokens: ['#2-1'] },
+      ],
+      [
+        'update',
+        {
+          namespace: 'test',
+          name: 'package',
+          level: 'notice',
+          levelIndex: 2,
+          textTokens: ['#3-1'],
+        },
+      ],
     ]);
   });
 
@@ -75,10 +114,22 @@ describe('lib/log/get-progress-reporter.js', () => {
     progress1.remove();
 
     expect(events).to.deep.equal([
-      ['update', { id: 'test:upload', level: 'notice', levelIndex: 2, textTokens: ['#1-1'] }],
-      ['update', { id: 'other:upload', level: 'notice', levelIndex: 2, textTokens: ['#2-1'] }],
-      ['remove', { id: 'other:upload' }],
-      ['remove', { id: 'test:upload' }],
+      [
+        'update',
+        { namespace: 'test', name: 'upload', level: 'notice', levelIndex: 2, textTokens: ['#1-1'] },
+      ],
+      [
+        'update',
+        {
+          namespace: 'other',
+          name: 'upload',
+          level: 'notice',
+          levelIndex: 2,
+          textTokens: ['#2-1'],
+        },
+      ],
+      ['remove', { namespace: 'other', name: 'upload' }],
+      ['remove', { namespace: 'test', name: 'upload' }],
     ]);
   });
 });

--- a/test/log.js
+++ b/test/log.js
@@ -171,4 +171,33 @@ describe('log', () => {
       expect(typeof log.progress.get('some-progress').info).to.equal('function');
     });
   });
+
+  describe('`getPluginWriters`', () => {
+    let testWriters;
+    before(() => {
+      testWriters = log.getPluginWriters('test');
+    });
+
+    it('should expose event logging interface', () => {
+      const testLog = testWriters.log;
+      expect(typeof testLog.debug).to.equal('function');
+      expect(typeof testLog.info).to.equal('function');
+      expect(typeof testLog.notice).to.equal('function');
+      expect(typeof testLog.warn).to.equal('function');
+      expect(typeof testLog.error).to.equal('function');
+      expect(typeof testLog.get).to.equal('function');
+    });
+
+    it('should expose output writing interface', () => {
+      expect(typeof testWriters.writeText).to.equal('function');
+    });
+
+    it('should expose progress writing interface', () => {
+      expect(typeof testWriters.progress.get('some-progress').info).to.equal('function');
+    });
+
+    it('should create one set of writers for a plugin', () => {
+      expect(testWriters).to.equal(log.getPluginWriters('test'));
+    });
+  });
 });


### PR DESCRIPTION
Addresses: https://github.com/serverless/serverless/issues/9860

Additionally:
- Refactor `writeText` to rely on emitter interface in similar manner as `progress` (as same as it's with `progress` we need to create different instance and when processing invocations we need to be tell from which source they're coming from)
- Improve signature of events as send with `progress` updates.