### PR TITLE
Log: Node.js CLI reporter for dynamic progress

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -75,14 +75,14 @@ Basic API exposes:
 - `debug`, `info`, `notice`, `warn`, `error` - functions to write messages at given levels
 - `get` - Function to obtain additionally namespaced logger (e.g. `log.get('aws-deploy'))` will return a logger additionally namespace to `aws-deploy` (full namespace will be `serverless:aws-deploy`). Returned logger shares same interface as described in this points
 
-### Currently applied log level information
+### Environment characteristics
 
-Ideally we should not deal with a situation where applied log levels influence how log messages are constructed.
-Still we cannot seclude scenario where intention will be to show some messages exchangably depending on wether we're in verbose mode or not.
-It's the reason below interface was introduced, it should be used as last resort.
+Ideally we should not deal with a situation where characteristics of environment influence how log messages are constructed.
+Still we cannot seclude scenario where intention will be to e.g. show some messages exchangably depending on wether we're in verbose mode or not. It's the reason below interface was introduced, they should be used as last resort.
 
 - `logLevelIndex` - Index of used log level (An array index from [levels](https://github.com/medikoo/log/blob/master/levels.json) list)
-- `isVerboseMode` - Weather we're in verbose mode or not (verbose mode is assumed if log level is set to _info_ or _debug_)
+- `isVerboseMode` - Whether we're in verbose mode or not (verbose mode is assumed if log level is set to _info_ or _debug_)
+- `isInteractive` - Whether we're in context of interactive terminal
 
 ### `writeText(textToken, ..textTokens)` Interface to write final outcome of the command
 

--- a/lib/log-reporters/node/log-reporter.js
+++ b/lib/log-reporters/node/log-reporter.js
@@ -9,9 +9,9 @@ const WARNING_LEVEL_INDEX = logLevels.indexOf('warning');
 const ERROR_LEVEL_INDEX = logLevels.indexOf('error');
 
 class ServerlessLogReporter extends NodeLogReporter {
-  constructor() {
+  constructor({ logLevelIndex, debugNamespaces }) {
     super({
-      env: { LOG_LEVEL: process.env.SLS_LOG_LEVEL, LOG_DEBUG: process.env.SLS_LOG_DEBUG },
+      env: { LOG_LEVEL: logLevels[logLevelIndex], LOG_DEBUG: debugNamespaces },
       defaultNamespace: 'serverless',
     });
   }
@@ -41,4 +41,4 @@ ServerlessLogReporter.resolveNamespaceMessagePrefix = function (logger) {
   return `${logger.namespaceTokens.slice(1).join(':')}:`;
 };
 
-module.exports = () => new ServerlessLogReporter();
+module.exports = (config) => new ServerlessLogReporter(config);

--- a/lib/log-reporters/node/progress-reporter.js
+++ b/lib/log-reporters/node/progress-reporter.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const getCliProgressFooter = require('cli-progress-footer');
+const chalk = require('chalk');
+const { emitter } = require('../../log/get-progress-reporter');
+const joinTextTokens = require('../../log/join-text-tokens');
+
+module.exports = ({ logLevelIndex }) => {
+  const cliProgressFooter = getCliProgressFooter();
+  cliProgressFooter.shouldAddProgressAnimationPrefix = true;
+  cliProgressFooter.progressAnimationPrefixFrames =
+    cliProgressFooter.progressAnimationPrefixFrames.map((frame) => chalk.red(frame));
+
+  const ongoing = new Map();
+  const repaint = () => cliProgressFooter.updateProgress(Array.from(ongoing.values()));
+
+  emitter.on('update', ({ namespace, name, levelIndex, textTokens }) => {
+    if (levelIndex > logLevelIndex) return;
+    ongoing.set(`${namespace}:${name}`, joinTextTokens(textTokens).slice(0, -1));
+    repaint();
+  });
+  emitter.on('remove', ({ namespace, name }) => {
+    ongoing.delete(`${namespace}:${name}`);
+    repaint();
+  });
+};

--- a/lib/log/join-text-tokens.js
+++ b/lib/log/join-text-tokens.js
@@ -5,7 +5,7 @@
 const ensureString = require('type/string/ensure');
 const _ = require('lodash');
 
-module.exports = (...textTokens) =>
+module.exports = (textTokens) =>
   `${_.flattenDeep(textTokens)
     .map((textToken) => ensureString(textToken, { isOptional: true, name: 'textToken' }) || '')
     .join('\n')}\n`;

--- a/log-reporters/node.js
+++ b/log-reporters/node.js
@@ -22,6 +22,8 @@ const logLevelIndex = logLevels.includes(process.env.SLS_LOG_LEVEL)
   ? logLevels.indexOf(process.env.SLS_LOG_LEVEL)
   : logLevels.indexOf('notice');
 
+const isInteractive = process.stdin.isTTY || process.env.SLS_INTERACTIVE_SETUP_ENABLE;
+
 // Event logs
 logReporter({ logLevelIndex, debugNamespaces: process.env.SLS_LOG_DEBUG });
 log.logLevelIndex = logLevelIndex;
@@ -30,3 +32,8 @@ log.logLevelIndex = logLevelIndex;
 outputEmitter.on('write', ({ mode, textTokens }) => {
   if (mode === 'text') process.stdout.write(joinTextTokens(textTokens));
 });
+
+log.isInteractive = isInteractive;
+if (isInteractive) {
+  require('../lib/log-reporters/node/progress-reporter')({ logLevelIndex });
+}

--- a/log-reporters/node.js
+++ b/log-reporters/node.js
@@ -24,6 +24,7 @@ const logLevelIndex = logLevels.includes(process.env.SLS_LOG_LEVEL)
 
 // Event logs
 logReporter({ logLevelIndex, debugNamespaces: process.env.SLS_LOG_DEBUG });
+log.logLevelIndex = logLevelIndex;
 
 // Substantial output (not subject to filtering)
 outputEmitter.on('write', ({ mode, textTokens }) => {

--- a/log-reporters/node.js
+++ b/log-reporters/node.js
@@ -16,9 +16,14 @@ if (!(logMode & 1)) return;
 const logReporter = require('../lib/log-reporters/node/log-reporter');
 const { emitter: outputEmitter } = require('../lib/log/get-output-reporter');
 const joinTextTokens = require('../lib/log/join-text-tokens');
+const logLevels = require('log/levels');
+
+const logLevelIndex = logLevels.includes(process.env.SLS_LOG_LEVEL)
+  ? logLevels.indexOf(process.env.SLS_LOG_LEVEL)
+  : logLevels.indexOf('notice');
 
 // Event logs
-logReporter();
+logReporter({ logLevelIndex, debugNamespaces: process.env.SLS_LOG_DEBUG });
 
 // Substantial output (not subject to filtering)
 outputEmitter.on('write', ({ mode, textTokens }) => {

--- a/log.js
+++ b/log.js
@@ -50,6 +50,9 @@ Object.defineProperty(module.exports, 'isVerboseMode', {
   enumerable: true,
 });
 
+// Whether we're in context of interactive terminal (to be overriden by process main module)
+module.exports.isInteractive = false;
+
 module.exports.writeText = getOutputReporter('serverless').get('text');
 
 module.exports.progress = getProgressReporter('serverless');

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "archive-type": "^4.0.0",
     "chalk": "^4.1.2",
     "ci-info": "^3.2.0",
+    "cli-progress-footer": "^2.0.0",
     "content-disposition": "^0.5.3",
     "decompress": "^4.2.1",
     "event-emitter": "^0.3.5",

--- a/test/lib/log/join-test-tokens.js
+++ b/test/lib/log/join-test-tokens.js
@@ -5,18 +5,18 @@ const joinTextTokens = require('../../../lib/log/join-text-tokens');
 
 describe('lib/log/join-text-tokens.js', () => {
   it('should add new line at the of text', () => {
-    expect(joinTextTokens('foo bar')).to.equal('foo bar\n');
+    expect(joinTextTokens(['foo bar'])).to.equal('foo bar\n');
   });
   it('should join separate text tokens into multiline text', () => {
-    expect(joinTextTokens('foo', 'bar', 'other')).to.equal('foo\nbar\nother\n');
+    expect(joinTextTokens(['foo', 'bar', 'other'])).to.equal('foo\nbar\nother\n');
   });
   it('should resolve text tokens from input arrays recursively', () => {
-    expect(joinTextTokens('foo', ['bar', 'other', ['lorem', 'ipsum'], 'elo'], 'final')).to.equal(
+    expect(joinTextTokens(['foo', ['bar', 'other', ['lorem', 'ipsum'], 'elo'], 'final'])).to.equal(
       'foo\nbar\nother\nlorem\nipsum\nelo\nfinal\n'
     );
   });
   it('should treat `null` and `undefined` values as empty stirngs', () => {
-    expect(joinTextTokens('foo', null, 'bar', undefined, 'other')).to.equal(
+    expect(joinTextTokens(['foo', null, 'bar', undefined, 'other'])).to.equal(
       'foo\n\nbar\n\nother\n'
     );
   });

--- a/test/log-reporters/node.js
+++ b/test/log-reporters/node.js
@@ -132,4 +132,77 @@ describe('log-reporters/node.js', () => {
       expect(stderrData).to.include('Error log');
     });
   });
+
+  describe('Modern logs: Progress', () => {
+    let progress;
+    let restoreEnv;
+    let stdoutData = '';
+    let restoreStdoutWrite;
+    before(() => {
+      ({ restoreEnv } = overrideEnv());
+      ({ restoreStdoutWrite } = overrideStdoutWrite((data, originalWrite) => {
+        stdoutData += data;
+        originalWrite(data);
+      }));
+      process.env.SLS_DEV_LOG_MODE = 1;
+      process.env.SLS_INTERACTIVE_SETUP_ENABLE = 1;
+      ({ progress } = getLog());
+    });
+
+    after(() => {
+      restoreStdoutWrite();
+      restoreEnv();
+    });
+
+    it('should write progress of notice levels', () => {
+      const progressItem = progress.get('first');
+      progressItem.notice('Notice progress');
+      progressItem.remove();
+      expect(stdoutData).to.include('Notice progress');
+    });
+
+    it('should not write progress of info levels', () => {
+      const progressItem = progress.get('first');
+      progressItem.info('Info progress');
+      progressItem.remove();
+      expect(stdoutData).to.not.include('Info progress');
+    });
+  });
+
+  describe('Modern logs: Progress: Verbose', () => {
+    let progress;
+    let restoreEnv;
+    let stdoutData = '';
+    let restoreStdoutWrite;
+    before(() => {
+      ({ restoreEnv } = overrideEnv());
+      ({ restoreStdoutWrite } = overrideStdoutWrite((data, originalWrite) => {
+        stdoutData += data;
+        originalWrite(data);
+      }));
+      process.env.SLS_DEV_LOG_MODE = 1;
+      process.env.SLS_LOG_LEVEL = 'info';
+      process.env.SLS_INTERACTIVE_SETUP_ENABLE = 1;
+      ({ progress } = getLog());
+    });
+
+    after(() => {
+      restoreStdoutWrite();
+      restoreEnv();
+    });
+
+    it('should write progress of notice levels', () => {
+      const progressItem = progress.get('first');
+      progressItem.notice('Notice progress');
+      progressItem.remove();
+      expect(stdoutData).to.include('Notice progress');
+    });
+
+    it('should write progress of info levels', () => {
+      const progressItem = progress.get('first');
+      progressItem.info('Info progress');
+      progressItem.remove();
+      expect(stdoutData).to.include('Info progress');
+    });
+  });
 });

--- a/test/log-reporters/node.js
+++ b/test/log-reporters/node.js
@@ -114,9 +114,9 @@ describe('log-reporters/node.js', () => {
     after(() => restoreEnv());
 
     it('should write logs of all levels', () => {
-      let stdoutData = '';
+      let stderrData = '';
       overrideStderrWrite(
-        (data) => (stdoutData += data),
+        (data) => (stderrData += data),
         () => {
           log.info('Info log');
           log.debug('Debug log');
@@ -125,11 +125,11 @@ describe('log-reporters/node.js', () => {
           log.error('Error log');
         }
       );
-      expect(stdoutData).to.include('Debug log');
-      expect(stdoutData).to.include('Info log');
-      expect(stdoutData).to.include('Notice log');
-      expect(stdoutData).to.include('Warn log');
-      expect(stdoutData).to.include('Error log');
+      expect(stderrData).to.include('Debug log');
+      expect(stderrData).to.include('Info log');
+      expect(stderrData).to.include('Notice log');
+      expect(stderrData).to.include('Warn log');
+      expect(stderrData).to.include('Error log');
     });
   });
 });


### PR DESCRIPTION
Addresses: serverless/serverless#9860

Additionally I've exposed `isInteractive` on `log`, in case we will need to tweak logs configuration in response to this environment characteristics. I hope it won't be the case, but current design proposes it.

