### PR TITLE
Log: Ensure writing functions respect mocked `stdout.write`

### DIFF
--- a/log.js
+++ b/log.js
@@ -25,12 +25,14 @@ const getLegacyLog =
     else write(`${print(message)}\n`);
   };
 
-module.exports = getLegacyLog(process.stdout.write.bind(process.stdout));
+// Note: Do not assign prebound function as it breaks in tests mocking of process.stdout.write
+module.exports = getLegacyLog((...args) => process.stdout.write(...args));
 
 // Legacy interface, used for old logs which have counterpart in new logs
 // (are to be shown exchangeably)
 const legacy = {
-  write: process.stdout.write.bind(process.stdout),
+  // Note: Do not assign prebound function as it breaks in tests mocking of process.stdout.write
+  write: (...args) => process.stdout.write(...args),
   consoleLog: (message) => {
     legacy.write(`${message}\n`);
   },


### PR DESCRIPTION
After releasing v5.8.0 tests in Framework suddenly started to fail.

It's the outcome of _innocent_  looking refactor made with: https://github.com/serverless/utils/commit/c7338bfc3cd9423c3fc8969bf20b938e03e6bdda

This effectively made our current logging not susceptible to `process.stdout.write` mocking, and that's done in numerous places in tests.

This patch fixes that