### PR TITLE
Log: `progress.clear` to clear and close progress output

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -124,8 +124,14 @@ Write progress update on given item. Each update will overwrite previous update.
 
 Clear operation from progress bar (calling it means that processing of it ended)
 
+#### `progress.clear()`
+
+Clears all the progress and prevents further writing to it.
+
+_Note: Not exposed to plugins and not intended to be used in their context_
+
 ### `getPluginWriters(pluginName)` Get log & output writing functions dedicated for external plugins
 
 _Note this part of an API is still experimental and subject to changes (not advertised to be used by external plugins)_
 
-Returns `{ log, writeText, progress }` interface, same as one documented above, but dedicated to be used in context of external (named via `pluginName`) plugins. Calling function again, with same plugin name, will return previously created interface.
+Returns `{ log, writeText, progress }` interface, same as one documented above (excluding `progress.clear`), but dedicated to be used in context of external (named via `pluginName`) plugins. Calling function again, with same plugin name, will return previously created interface.

--- a/lib/log-reporters/node/progress-reporter.js
+++ b/lib/log-reporters/node/progress-reporter.js
@@ -3,6 +3,7 @@
 const getCliProgressFooter = require('cli-progress-footer');
 const chalk = require('chalk');
 const { emitter } = require('../../log/get-progress-reporter');
+const { progress } = require('../../../log');
 const joinTextTokens = require('../../log/join-text-tokens');
 
 module.exports = ({ logLevelIndex }) => {
@@ -11,8 +12,16 @@ module.exports = ({ logLevelIndex }) => {
   cliProgressFooter.progressAnimationPrefixFrames =
     cliProgressFooter.progressAnimationPrefixFrames.map((frame) => chalk.red(frame));
 
+  let isClosed = false;
+  progress.clear = () => {
+    isClosed = true;
+    cliProgressFooter.updateProgress();
+  };
   const ongoing = new Map();
-  const repaint = () => cliProgressFooter.updateProgress(Array.from(ongoing.values()));
+  const repaint = () => {
+    if (isClosed) return;
+    cliProgressFooter.updateProgress(Array.from(ongoing.values()));
+  };
 
   emitter.on('update', ({ namespace, name, levelIndex, textTokens }) => {
     if (levelIndex > logLevelIndex) return;

--- a/log.js
+++ b/log.js
@@ -58,6 +58,9 @@ module.exports.isInteractive = false;
 module.exports.writeText = getOutputReporter('serverless').get('text');
 
 module.exports.progress = getProgressReporter('serverless');
+// Method intended to clear and close indefinitely any progress writing
+// Overriden with intended logic in reporter
+module.exports.progress.clear = () => {};
 
 module.exports.getPluginWriters = memoizee(
   (pluginName) => {

--- a/test/log-reporters/node.js
+++ b/test/log-reporters/node.js
@@ -148,6 +148,9 @@ describe('log-reporters/node.js', () => {
       process.env.SLS_INTERACTIVE_SETUP_ENABLE = 1;
       ({ progress } = getLog());
     });
+    beforeEach(() => {
+      stdoutData = '';
+    });
 
     after(() => {
       restoreStdoutWrite();
@@ -166,6 +169,13 @@ describe('log-reporters/node.js', () => {
       progressItem.info('Info progress');
       progressItem.remove();
       expect(stdoutData).to.not.include('Info progress');
+    });
+    it('should prevent any writing after `clear` method is invoked', () => {
+      const progressItem = progress.get('first');
+      progress.clear();
+      progressItem.notice('Notice progress');
+      progressItem.remove();
+      expect(stdoutData).to.not.include('Notice progress');
     });
   });
 

--- a/test/log.js
+++ b/test/log.js
@@ -170,6 +170,9 @@ describe('log', () => {
     it('should expose progress interface', () => {
       expect(typeof log.progress.get('some-progress').info).to.equal('function');
     });
+    it('should expose `clear` method', () => {
+      expect(typeof log.progress.clear).to.equal('function');
+    });
   });
 
   describe('`getPluginWriters`', () => {


### PR DESCRIPTION
A mean to indefinitely clear and close progress output, needed to be used especially when exception occurs