### PR TITLE
Log: Main progress instance to cover entire command progress

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -124,6 +124,14 @@ Write progress update on given item. Each update will overwrite previous update.
 
 Clear operation from progress bar (calling it means that processing of it ended)
 
+#### `progress.get('main')`
+
+Returns special instance of progress item, dedicated to cover progress of a complete command. It shares same interface as above, but (through reporter implementation) it behaves differently:
+
+- It's guaranteed to always be displayed at the top
+- Time counter is displayed aside of it (starting counting from first write)
+- It's not removed until command ends processing (`remove` is not effective, progress is cleared only after `progress.clear`)
+
 #### `progress.clear()`
 
 Clears all the progress and prevents further writing to it.

--- a/lib/log-reporters/node/progress-reporter.js
+++ b/lib/log-reporters/node/progress-reporter.js
@@ -12,24 +12,49 @@ module.exports = ({ logLevelIndex }) => {
   cliProgressFooter.progressAnimationPrefixFrames =
     cliProgressFooter.progressAnimationPrefixFrames.map((frame) => chalk.red(frame));
 
+  let mainProgressTextContent;
+  let mainProgressIntervalId;
+  let mainProgressStartTime;
+
   let isClosed = false;
   progress.clear = () => {
     isClosed = true;
+    clearInterval(mainProgressIntervalId);
     cliProgressFooter.updateProgress();
   };
-  const ongoing = new Map();
+
+  const ongoingSubProgress = new Map();
   const repaint = () => {
     if (isClosed) return;
-    cliProgressFooter.updateProgress(Array.from(ongoing.values()));
+    const progressItems = [];
+    if (mainProgressStartTime) {
+      progressItems.push(
+        `${mainProgressTextContent} ${chalk.gray(
+          `(${Math.floor((Date.now() - mainProgressStartTime) / 1000)}s)`
+        )}`
+      );
+    }
+    progressItems.push(...ongoingSubProgress.values());
+    cliProgressFooter.updateProgress(progressItems);
   };
 
   emitter.on('update', ({ namespace, name, levelIndex, textTokens }) => {
     if (levelIndex > logLevelIndex) return;
-    ongoing.set(`${namespace}:${name}`, joinTextTokens(textTokens).slice(0, -1));
+    const textContent = joinTextTokens(textTokens).slice(0, -1);
+    if (namespace === 'serverless' && name === 'main') {
+      // Main progress
+      mainProgressTextContent = textContent;
+      if (!mainProgressStartTime) {
+        mainProgressStartTime = Date.now();
+        mainProgressIntervalId = setInterval(repaint, 200);
+      }
+    } else {
+      ongoingSubProgress.set(`${namespace}:${name}`, textContent);
+    }
     repaint();
   });
   emitter.on('remove', ({ namespace, name }) => {
-    ongoing.delete(`${namespace}:${name}`);
+    ongoingSubProgress.delete(`${namespace}:${name}`);
     repaint();
   });
 };

--- a/test/log-reporters/node.js
+++ b/test/log-reporters/node.js
@@ -153,6 +153,7 @@ describe('log-reporters/node.js', () => {
     });
 
     after(() => {
+      progress.clear();
       restoreStdoutWrite();
       restoreEnv();
     });
@@ -170,6 +171,13 @@ describe('log-reporters/node.js', () => {
       progressItem.remove();
       expect(stdoutData).to.not.include('Info progress');
     });
+
+    it('should write main progress', () => {
+      const progressItem = progress.get('main');
+      progressItem.notice('Packaging');
+      expect(stdoutData).to.include('Packaging (0s)');
+    });
+
     it('should prevent any writing after `clear` method is invoked', () => {
       const progressItem = progress.get('first');
       progress.clear();


### PR DESCRIPTION
Addresses: serverless/serverless#9860

### `progress.get('main')`

Returns special instance progress, dedicated to cover complete command progress. It shares same interface as any other progress item, but (through reporter implementation) it behaves differently:
- It's guaranteed to always be displayed at the top
- Time counter is displayed aside of it (starting counting from first update)
- It's not removed until command ends processing (`remove` is not effective, progress is cleared only after `progress.clear`)
