### PR TITLE
Log: Support multiline input in style decorators

### DIFF
--- a/docs/log.md
+++ b/docs/log.md
@@ -148,11 +148,11 @@ Returns `{ log, writeText, progress }` interface, same as one documented above (
 
 _Note this part of an API is still experimental and subject to changes (not advertised to be used by external plugins)_
 
-Decorators that ensure that in given environment intended style can be reproduced.
+Decorators that ensure that in given environment intended style can be reproduced. Multiline input can be pased with different text tokens (each will be presented on new line)
 
 Available style functions:
 
-- `aside` - for messsage side content
-- `noticeSymbol` - for symbols shown aside of regular notifications
-- `warning` - for warnings
-- `error` - for errors
+- `aside(text, ...textTokens)` - for messsage side content
+- `noticeSymbol(text, ...textTokens)` - for symbols shown aside of regular notifications
+- `warning(text, ...textTokens)` - for warnings
+- `error(text, ...textTokens)` - for errors

--- a/lib/log-reporters/node/style.js
+++ b/lib/log-reporters/node/style.js
@@ -2,8 +2,9 @@
 
 const chalk = require('chalk');
 const { style } = require('../../../log');
+const joinTextTokens = require('../../log/join-text-tokens');
 
-module.exports = {
+const cliStyle = {
   aside: chalk.rgb(140, 141, 145),
   noticeSymbol: chalk.rgb(253, 87, 80),
   warning: chalk.rgb(255, 165, 0),
@@ -11,5 +12,8 @@ module.exports = {
 };
 
 for (const key of Object.keys(style)) {
-  if (module.exports[key]) style[key] = module.exports[key];
+  const decorator = cliStyle[key];
+  if (!decorator) continue;
+  module.exports[key] = style[key] = (text, ...textTokens) =>
+    decorator(joinTextTokens([text, ...textTokens]).slice(0, -1));
 }

--- a/log.js
+++ b/log.js
@@ -79,8 +79,8 @@ module.exports.getPluginWriters = memoizee(
 );
 
 module.exports.style = {
-  aside: (message) => message,
-  noticeSymbol: (message) => message,
-  warning: (message) => message,
-  error: (message) => message,
+  aside: (text, ...textTokens) => [text, ...textTokens],
+  noticeSymbol: (text, ...textTokens) => [text, ...textTokens],
+  warning: (text, ...textTokens) => [text, ...textTokens],
+  error: (text, ...textTokens) => [text, ...textTokens],
 };


### PR DESCRIPTION
When reviewing work done so far, I've observed that it'll be convienient to be able to setup constructs as:

```javascript
writeText(style.aside(
  "First line",
  "Second line",
  "etc."
));
```

Providing multiline input that way is supported by `writeText`, but was not by style decorators, which when involved required using them on each line independently. This patch improves that interface