### PR TITLE
Release v5.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [5.12.0](https://github.com/serverless/utils/compare/v5.11.0...v5.12.0) (2021-09-14)
+
+### Features
+
+- **Log:** Improve styles when just 16 or 256 colors are supported ([#121](https://github.com/serverless/utils/pull/121)) ([668362d](https://github.com/serverless/utils/commit/668362d3ef2159b075408bac2427b09a5aa2f9b4)) ([d97bf24](https://github.com/serverless/utils/commit/d97bf240ee853c684247b6cdc8a38a810114504f)) ([Mariusz Nowak](https://github.com/medikoo))
+
 ## [5.11.0](https://github.com/serverless/utils/compare/v5.10.0...v5.11.0) (2021-09-10)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "archive-type": "^4.0.0",
     "chalk": "^4.1.2",
     "ci-info": "^3.2.0",
-    "cli-progress-footer": "^2.0.0",
+    "cli-progress-footer": "^2.0.2",
     "content-disposition": "^0.5.3",
     "decompress": "^4.2.1",
     "event-emitter": "^0.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/utils",
-  "version": "5.11.0",
+  "version": "5.12.0",
   "description": "Serverless CLI utilities",
   "repository": "serverless/utils",
   "homepage": "https://github.com/serverless/utils#readme",


### PR DESCRIPTION
It ensures we will rely on fixed version of `cli-progress-footer` (has fixed handling of that printing `.` issue)