### PR TITLE
Log: Do not write level prefix with deprecation warnings

### DIFF
--- a/lib/log-reporters/node/log-reporter.js
+++ b/lib/log-reporters/node/log-reporter.js
@@ -2,6 +2,7 @@
 
 const NodeLogReporter = require('log-node/lib/writer');
 const logLevels = require('log/levels');
+const logEmitter = require('log/lib/emitter');
 const colorsSupportLevel = require('supports-color').stderr.level || 0;
 const style = require('./style');
 
@@ -13,6 +14,13 @@ class ServerlessLogReporter extends NodeLogReporter {
     super({
       env: { LOG_LEVEL: logLevels[logLevelIndex], LOG_DEBUG: debugNamespaces },
       defaultNamespace: 'serverless',
+    });
+
+    // Prevent "Warning:" prefix on deprecation warnings
+    logEmitter.on('init', ({ logger }) => {
+      if (logger.namespace === 'serverless:deprecation') {
+        logger.levelMessagePrefix = null;
+      }
     });
   }
   isLoggerEnabled(logger) {

--- a/test/log-reporters/node.js
+++ b/test/log-reporters/node.js
@@ -78,6 +78,28 @@ describe('log-reporters/node.js', () => {
       expect(stderrData).to.include('Error log');
     });
 
+    it('should write level prefixes', () => {
+      let stderrData = '';
+      overrideStderrWrite(
+        (data) => (stderrData += data),
+        () => {
+          log.warn('Warn log');
+        }
+      );
+      expect(stderrData).to.include('Warning: ');
+    });
+
+    it('should not write level prefixes on deprecation logs', () => {
+      let stderrData = '';
+      overrideStderrWrite(
+        (data) => (stderrData += data),
+        () => {
+          log.get('deprecation').warn('Warn log');
+        }
+      );
+      expect(stderrData).to.not.include('Warning: ');
+    });
+
     it('should not write logs of debug and info levels', () => {
       let stderrData = '';
       overrideStderrWrite(


### PR DESCRIPTION
Needed for https://github.com/serverless/serverless/pull/9960