### PR TITLE
v6: Log: Support for `--verbose` and `--debug` flags

### DIFF
--- a/lib/log-reporters/node/log-reporter.js
+++ b/lib/log-reporters/node/log-reporter.js
@@ -11,6 +11,13 @@ const ERROR_LEVEL_INDEX = logLevels.indexOf('error');
 
 class ServerlessLogReporter extends NodeLogReporter {
   constructor({ logLevelIndex, debugNamespaces }) {
+    if (debugNamespaces) {
+      debugNamespaces = debugNamespaces
+        .split(',')
+        .filter(Boolean)
+        .map((namespace) => `serverless:${namespace}`)
+        .join(',');
+    }
     super({
       env: { LOG_LEVEL: logLevels[logLevelIndex], LOG_DEBUG: debugNamespaces },
       defaultNamespace: 'serverless',

--- a/log-reporters/node.js
+++ b/log-reporters/node.js
@@ -8,10 +8,8 @@ uniGlobal.legacyLogWrite = () => {};
 
 // Show modern logs
 
-if (!process.env.SLS_LOG_LEVEL && process.argv.includes('--verbose')) {
+if (process.env.SLS_LOG_LEVEL !== 'debug' && process.argv.includes('--verbose')) {
   process.env.SLS_LOG_LEVEL = 'info';
-  // TODO: Remove once support for global --verbose mode is added
-  process.argv.splice(process.argv.indexOf('--verbose'), 1);
 }
 
 const logReporter = require('../lib/log-reporters/node/log-reporter');

--- a/log-reporters/node.js
+++ b/log-reporters/node.js
@@ -12,6 +12,18 @@ if (process.env.SLS_LOG_LEVEL !== 'debug' && process.argv.includes('--verbose'))
   process.env.SLS_LOG_LEVEL = 'info';
 }
 
+process.argv.some((flag, index) => {
+  const namespace = (() => {
+    if (flag === '--debug') return process.argv[index + 1];
+    if (flag.startsWith('--debug=')) return flag.slice('--debug='.length);
+    return null;
+  })();
+  if (!namespace) return false;
+  if (namespace === '*') process.env.SLS_LOG_LEVEL = 'debug';
+  else process.env.SLS_LOG_DEBUG = namespace;
+  return true;
+});
+
 const logReporter = require('../lib/log-reporters/node/log-reporter');
 const { emitter: outputEmitter } = require('../lib/log/get-output-reporter');
 const joinTextTokens = require('../lib/log/join-text-tokens');

--- a/test/log-reporters/node.js
+++ b/test/log-reporters/node.js
@@ -218,6 +218,34 @@ describe('log-reporters/node.js', () => {
         expect(stderrData).to.not.include('Debug log');
       });
     });
+
+    describe('--debug flag', () => {
+      let log;
+      let restoreEnv;
+      let restoreArgv;
+      before(() => {
+        ({ restoreEnv } = overrideEnv());
+        ({ restoreArgv } = overrideArgv({ args: ['serverless', '--debug=foo'] }));
+        ({ log } = getLog());
+      });
+      after(() => {
+        restoreEnv();
+        restoreArgv();
+      });
+
+      it('should write debug level logs for specified namespace', () => {
+        let stderrData = '';
+        overrideStderrWrite(
+          (data) => (stderrData += data),
+          () => {
+            log.get('foo').debug('Foo debug log');
+            log.get('bar').debug('Bar debug log');
+          }
+        );
+        expect(stderrData).to.include('Foo debug log');
+        expect(stderrData).to.not.include('Bar debug log');
+      });
+    });
   });
 
   describe('Modern logs: Style', () => {


### PR DESCRIPTION
Schema for commands is updated at https://github.com/serverless/serverless/pull/10197