### PR TITLE
Upgrade dependencies

### DIFF
--- a/inquirer/index.js
+++ b/inquirer/index.js
@@ -2,14 +2,13 @@
 
 'use strict';
 
+const { createRequire } = require('module');
 const identity = require('ext/function/identity');
-const { dirname } = require('path');
 const requireUncached = require('ncjsm/require-uncached');
-const resolve = require('ncjsm/resolve/sync');
 const chalk = require('chalk');
 const { style } = require('../log');
 
-const inquirersChalkPath = resolve(dirname(require.resolve('inquirer')), 'chalk').realPath;
+const inquirersChalkPath = createRequire(require.resolve('inquirer')).resolve('chalk');
 
 module.exports = requireUncached(inquirersChalkPath, () => {
   // Ensure distinct chalk instance for inquirer and hack it with altered styles

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@commitlint/cli": "^16.1.0",
     "@serverless/eslint-config": "^4.0.0",
-    "@serverless/test": "^9.0.0",
+    "@serverless/test": "^10.0.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
     "eslint": "^8.8.0",
@@ -49,7 +49,7 @@
     "husky": "^4.3.8",
     "is-zip": "^1.0.0",
     "lint-staged": "^12.3.2",
-    "mocha": "^8.4.0",
+    "mocha": "^9.2.0",
     "nock": "^13.2.2",
     "nyc": "^15.1.0",
     "prettier": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "type": "^2.5.0",
     "uni-global": "^1.0.0",
     "uuid": "^8.3.2",
-    "write-file-atomic": "^3.0.3"
+    "write-file-atomic": "^4.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^12.1.4",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "github-release-from-cc-changelog": "^2.2.0",
     "husky": "^4.3.8",
     "is-zip": "^1.0.0",
-    "lint-staged": "^10.5.4",
+    "lint-staged": "^12.3.2",
     "mocha": "^8.4.0",
     "nock": "^13.2.2",
     "nyc": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "filenamify": "^4.3.0",
     "get-stream": "^6.0.1",
     "got": "^11.8.3",
-    "inquirer": "^7.3.3",
+    "inquirer": "^8.2.0",
     "js-yaml": "^4.1.0",
     "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "process-utils": "^4.0.0",
     "proxyquire": "^2.1.3",
     "random-buffer": "^0.1.0",
-    "sinon": "^12.0.1",
+    "sinon": "^13.0.1",
     "sinon-chai": "^3.7.0",
     "standard-version": "^9.3.2",
     "timers-ext": "^0.1.7"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "write-file-atomic": "^4.0.0"
   },
   "devDependencies": {
-    "@commitlint/cli": "^12.1.4",
+    "@commitlint/cli": "^16.1.0",
     "@serverless/eslint-config": "^4.0.0",
     "@serverless/test": "^8.8.0",
     "chai": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@commitlint/cli": "^16.1.0",
     "@serverless/eslint-config": "^4.0.0",
-    "@serverless/test": "^8.8.0",
+    "@serverless/test": "^9.0.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
     "eslint": "^7.32.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@serverless/test": "^9.0.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^7.32.0",
+    "eslint": "^8.8.0",
     "eslint-plugin-import": "^2.25.4",
     "git-list-updated": "^1.2.1",
     "github-release-from-cc-changelog": "^2.2.0",


### PR DESCRIPTION
Upgrade dependencies that we can upgrade (we cannot upgrade to ESM only).

Additionally apply change proposed with https://github.com/serverless/utils/pull/75