### PR TITLE
Serverless Inc. CLI's `ServerlessError` to report user errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,14 @@ npm install @serverless/utils
 
 ### Utilities
 
+- [`account`](docs/account.md)
 - [`analyticsAndNotificationsUrl`](docs/analytics-and-notifications-url.md)
 - [`cloudformationSchema`](docs/cloudformation-schema.md)
 - [`config`](docs/config.md)
+- [`download`](docs/download.md)
+- [`getNotificationsMode`](docs/get-notifications-mode.md)
 - [`isInChina`](docs/is-in-china.md)
+- [`logReporters`](docs/log-reporters.md)
 - [`log`](docs/log.md)
 - [`processBackendNotificationRequest`](docs/process-backend-notification-request.md)
+- [`telemetry`](docs/telemetry.md)

--- a/README.md
+++ b/README.md
@@ -20,4 +20,5 @@ npm install @serverless/utils
 - [`logReporters`](docs/log-reporters.md)
 - [`log`](docs/log.md)
 - [`processBackendNotificationRequest`](docs/process-backend-notification-request.md)
+- [`ServerlessError`](docs/serverless-error.md)
 - [`telemetry`](docs/telemetry.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @serverless/utils
 
-## Serverless CLI utilities
+## Serverless Inc. CLIs internal utilities
 
 ### Installation
 

--- a/docs/serverless-error.md
+++ b/docs/serverless-error.md
@@ -1,0 +1,15 @@
+## Generic class to report user errors in Serverless Inc. CLI products
+
+### `ServerlessError(message, code, options = { ... })`
+
+- `message` - Error message
+- `code` - Error code
+- Supported `options` (all optional):
+  - `decoratedMessage` - Eventual decorated (with ANSI styling) version of a message to be passed throught to `stdout` as is
+
+```javascript
+const ServerlessError = require('@serverless/utils/serverless-error');
+...
+
+new ServerlessError("Service cannot be deployed in given region", 'REGION_MISMATCH');
+```

--- a/serverless-error.js
+++ b/serverless-error.js
@@ -1,0 +1,30 @@
+// WARNING: Do not use in utilities that are used by `serverless` v3.15.2 and lower
+// TODO: Remove above notice with the next major
+
+'use strict';
+
+const ensureString = require('type/string/ensure');
+const isObject = require('type/object/is');
+const ensure = require('type/ensure');
+
+class ServerlessError extends Error {
+  constructor(message, code, options = {}) {
+    [message, code] = ensure(['message', message, ensureString], ['code', code, ensureString]);
+    if (!isObject(options)) options = {};
+    const decoratedMessage = ensureString(options.decoratedMessage, {
+      name: 'options.decoratedMessage',
+      isOptional: true,
+    });
+    super(message);
+    this.code = code;
+    this.decoratedMessage = decoratedMessage;
+  }
+}
+
+Object.defineProperty(ServerlessError.prototype, 'name', {
+  value: ServerlessError.name,
+  configurable: true,
+  writable: true,
+});
+
+module.exports = ServerlessError;

--- a/test/serverless-error.js
+++ b/test/serverless-error.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const ServerlessError = require('../serverless-error');
+
+describe('test/serverless-error.test.js', () => {
+  it('should store message', () => {
+    const error = new ServerlessError('Some message', 'SOME_CODE');
+    expect(error.message).to.be.equal('Some message');
+  });
+
+  it('should expose constructor name', () => {
+    const error = new ServerlessError('Some message', 'SOME_CODE');
+    expect(error.name).to.be.equal('ServerlessError');
+  });
+
+  it('should store code', () => {
+    const error = new ServerlessError('Some message', 'ERROR_CODE');
+    expect(error.code).to.be.equal('ERROR_CODE');
+  });
+
+  it('should have stack trace', () => {
+    function testStackFrame() {
+      throw new ServerlessError('Some message', 'SOME_CODE');
+    }
+
+    try {
+      testStackFrame();
+    } catch (error) {
+      expect(error.stack).to.have.string('testStackFrame');
+    }
+  });
+});


### PR DESCRIPTION
Handling of a new identity system will be added in the scope of this package, which should serve any CLIs as maintained by our organization.

In new authentication utils I'd like to throw user errors, yet, at this point, `ServerlessError` is only available in `serverless` package. This PR is to generalize `ServerlessError` so it can be used by any of our CLI's.

Additonally cleaned up main documentation