### PR TITLE
API: Generalize and improve `apiRequest` uti

### DIFF
--- a/api-request.js
+++ b/api-request.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const ensureString = require('type/string/ensure');
+const isObject = require('type/object/is');
+const ensurePlainObject = require('type/plain-object/ensure');
 const fetch = require('node-fetch');
 const log = require('./log').log.get('auth');
 const ServerlessError = require('./serverless-error');
@@ -8,20 +10,28 @@ const backendUrl = require('./lib/auth/urls').backend;
 const resolveAuthToken = require('./auth/resolve-token');
 const resolveAuthMethod = require('./auth/resolve-mode');
 
-module.exports = async (pathname) => {
+module.exports = async (pathname, options = {}) => {
   pathname = ensureString(pathname, { name: 'pathname' });
+  if (!isObject(options)) options = {};
+  const method = ensureString(options.method, { name: 'options.method', default: 'GET' });
+  const body = ensurePlainObject(options.body, { name: 'options.body', isOptional: true });
   const authMethod = await resolveAuthMethod();
   if (!authMethod) throw new Error('Not authenticated to send request to the Console server');
   const response = await (async () => {
     const url = `${backendUrl}/api/identity${pathname}`;
-    const headers = { Authorization: `Bearer ${await resolveAuthToken()}` };
+    const headers = {
+      'Authorization': `Bearer ${await resolveAuthToken()}`,
+      'Content-Type': 'application/json',
+    };
     if (authMethod === 'org') headers['sls-token-type'] = 'orgToken';
-    log.debug('request: %s, headers %o', url, headers);
+    const fetchOptions = {
+      method,
+      headers,
+    };
+    if (body) fetchOptions.body = JSON.stringify(body);
+    log.debug('request: %s, options: %o', url, fetchOptions);
     try {
-      return await fetch(url, {
-        method: 'GET',
-        headers,
-      });
+      return await fetch(url, fetchOptions);
     } catch (error) {
       log.debug('Server unavailable', error);
       throw new ServerlessError(
@@ -30,6 +40,7 @@ module.exports = async (pathname) => {
       );
     }
   })();
+  log.debug('response: %d, headers: %o', response.status, response.headers);
   if (!response.ok) {
     const responseText = await response.text();
     if (response.status < 500) {
@@ -41,15 +52,18 @@ module.exports = async (pathname) => {
       'CONSOLE_SERVER_REQUEST_FAILED'
     );
   }
-  const responseData = await (async () => {
-    try {
-      return await response.json();
-    } catch (error) {
-      const responseText = await response.text();
-      log.debug('Canot resolve response JSON', error);
-      throw new Error(`Console server error: received unexpected response: ${responseText}`);
-    }
-  })();
-  log.debug('response: %o', responseData);
-  return responseData;
+  if ((response.headers.get('content-type') || '').includes('application/json')) {
+    const responseData = await (async () => {
+      try {
+        return await response.json();
+      } catch (error) {
+        const responseText = await response.text();
+        log.debug('Canot resolve response JSON', error);
+        throw new Error(`Console server error: received unexpected response: ${responseText}`);
+      }
+    })();
+    log.debug('response: %o', responseData);
+    return responseData;
+  }
+  return await response.text();
 };

--- a/api-request.js
+++ b/api-request.js
@@ -18,7 +18,7 @@ module.exports = async (pathname, options = {}) => {
   const authMethod = await resolveAuthMethod();
   if (!authMethod) throw new Error('Not authenticated to send request to the Console server');
   const response = await (async () => {
-    const url = `${backendUrl}/api/identity${pathname}`;
+    const url = `${backendUrl}${pathname}`;
     const headers = {
       'Authorization': `Bearer ${await resolveAuthToken()}`,
       'Content-Type': 'application/json',

--- a/api-request.js
+++ b/api-request.js
@@ -46,6 +46,7 @@ module.exports = async (pathname, options = {}) => {
     if (response.status < 500) {
       throw Object.assign(new Error(`Console server error: [${response.status}] ${responseText}`), {
         code: `CONSOLE_SERVER_ERROR_${response.status}`,
+        httpStatusCode: response.status,
       });
     }
     log.debug('Console server error %d %s', response.status, responseText);

--- a/api-request.js
+++ b/api-request.js
@@ -44,7 +44,9 @@ module.exports = async (pathname, options = {}) => {
   if (!response.ok) {
     const responseText = await response.text();
     if (response.status < 500) {
-      throw new Error(`Console server error: [${response.status}] ${responseText}`);
+      throw Object.assign(new Error(`Console server error: [${response.status}] ${responseText}`), {
+        code: `CONSOLE_SERVER_ERROR_${response.status}`,
+      });
     }
     log.debug('Console server error %d %s', response.status, responseText);
     throw new ServerlessError(

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -5,7 +5,7 @@ module.exports = {
     'body-leading-blank': [2, 'always'],
     'footer-leading-blank': [2, 'always'],
     'header-max-length': [2, 'always', 72],
-    'scope-enum': [2, 'always', ['', 'Auth', 'Config', 'Log']],
+    'scope-enum': [2, 'always', ['', 'API', 'Auth', 'Config', 'Log']],
     'subject-case': [2, 'always', 'sentence-case'],
     'subject-empty': [2, 'never'],
     'subject-full-stop': [2, 'never', '.'],

--- a/docs/api-request.md
+++ b/docs/api-request.md
@@ -1,13 +1,21 @@
 ## Serverless Inc. API request
 
-### `apiRequest(pathname)`
+### `apiRequest(pathname[, { method, body }])`
 
 Issue a request to Serverless Inc. API.
-
-At this point only basic GET requests are supported
 
 ```javascript
 const apiRequest = require('@serverless/utils/api-request');
 
 const { orgId: myOrgId } = await apiRequest('/orgs/name/my-org-name');
 ```
+
+#### Supported options
+
+##### `method`
+
+Request method
+
+##### `body`
+
+Body for request (only plain object is accepted)

--- a/test/api-request.test.js
+++ b/test/api-request.test.js
@@ -12,57 +12,89 @@ const log = require('../log').log.get('test');
 
 let api;
 describe('test/api-request.test.js', () => {
+  let lastMethod;
+  let lastRequestHeaders;
+  let lastRequestBody;
   beforeEach(() => {
+    const responseHeaders = new Map([['content-type', 'application/json; charset=utf-8']]);
     api = requireUncached(() =>
       proxyquire('../api-request', {
         './auth/resolve-token': async () => 'token',
         './auth/resolve-mode': async () => 'user',
-        'node-fetch': sinon.stub().callsFake(async (url, { method } = { method: 'GET' }) => {
-          log.debug('fetch request %s %o', url, method);
-          switch (method) {
-            case 'GET':
-              if (url.includes('/server-unavailable/')) {
-                throw new Error('Server error');
-              }
-              if (url.includes('/server-error/')) {
-                return {
-                  status: 500,
-                  text: async () => 'Server Error',
-                };
-              }
-              if (url.includes('/programmer-error/')) {
-                return {
-                  status: 400,
-                  text: async () => 'Programmer Error',
-                };
-              }
-              if (url.includes('/unexpected-response/')) {
-                return {
-                  ok: true,
-                  json: async () => {
-                    throw new Error('Parse Error');
-                  },
-                  text: async () => 'Unexpected response',
-                };
-              }
-              if (url.includes('/success/')) {
-                return {
-                  ok: true,
-                  json: async () => ({ foo: 'bar' }),
-                };
-              }
-              break;
+        'node-fetch': sinon
+          .stub()
+          .callsFake(async (url, { method, headers: requestHeaders, body } = { method: 'GET' }) => {
+            log.debug('fetch request %s %o', url, method);
+            lastMethod = method;
+            lastRequestHeaders = requestHeaders;
+            lastRequestBody = body;
+            switch (method) {
+              case 'GET':
+                if (url.includes('/server-unavailable/')) {
+                  throw new Error('Server error');
+                }
+                if (url.includes('/server-error/')) {
+                  return {
+                    status: 500,
+                    headers: responseHeaders,
+                    text: async () => 'Server Error',
+                  };
+                }
+                if (url.includes('/programmer-error/')) {
+                  return {
+                    status: 400,
+                    headers: responseHeaders,
+                    text: async () => 'Programmer Error',
+                  };
+                }
+                if (url.includes('/unexpected-response/')) {
+                  return {
+                    ok: true,
+                    headers: responseHeaders,
+                    json: async () => {
+                      throw new Error('Parse Error');
+                    },
+                    text: async () => 'Unexpected response',
+                  };
+                }
+                if (url.includes('/success/')) {
+                  return {
+                    ok: true,
+                    headers: responseHeaders,
+                    json: async () => ({ foo: 'bar' }),
+                  };
+                }
+                break;
+              case 'POST':
+                if (url.includes('/submission/')) {
+                  return {
+                    ok: true,
+                    headers: responseHeaders,
+                    json: async () => ({ foo: 'bar' }),
+                  };
+                }
+                break;
 
-            default:
-          }
-          throw new Error(`Unexpected request: ${url} method: ${method}`);
-        }),
+              default:
+            }
+            throw new Error(`Unexpected request: ${url} method: ${method}`);
+          }),
       })
     );
   });
 
   it('should handle success response', async () => {
     expect(await api('/success/')).to.deep.equal({ foo: 'bar' });
+    expect(lastMethod).to.equal('GET');
+  });
+
+  it('should handle post requests', async () => {
+    expect(await api('/submission/', { method: 'POST', body: { foo: 'bar' } })).to.deep.equal({
+      foo: 'bar',
+    });
+    expect(lastMethod).to.equal('POST');
+    expect(lastRequestHeaders['Content-Type']).to.equal('application/json');
+    expect(lastRequestBody).to.equal('{"foo":"bar"}');
   });
 
   it('should handle server unavailability', async () => {

--- a/test/api-request.test.js
+++ b/test/api-request.test.js
@@ -112,7 +112,10 @@ describe('test/api-request.test.js', () => {
   });
 
   it('should handle programmer error', async () => {
-    expect(api('/programmer-error/')).to.eventually.be.rejectedWith('Programmer Error');
+    expect(api('/programmer-error/')).to.eventually.be.rejected.and.have.property(
+      'code',
+      'CONSOLE_SERVER_ERROR_400'
+    );
   });
 
   it('should handle unexpected response', async () => {


### PR DESCRIPTION
- Support all HTTP `method`'s and provisioning of request `body`
- Configure error code for 4xx responses, and expose plain status on `httpStatusCode`
- Remove hardcoded URL prefix (breaking change, but API is still not in used, and implementation and at this point is considered as experimental)
- Improve debug logging