### PR TITLE
API: Improve authentication errors handling

### DIFF
--- a/api-request.js
+++ b/api-request.js
@@ -48,6 +48,26 @@ module.exports = async (pathname, options = {}) => {
     const responseText = await response.text();
     log.debug('[%d] %s', requestId, responseText);
     if (response.status < 500) {
+      if (response.status === 401) {
+        if (authMethod === 'org') {
+          throw Object.assign(
+            new ServerlessError(
+              'Unauthorized request: Either org token is invalid, ' +
+                'or org token is not supported for this command ' +
+                '(run the command as logged-in user instead)',
+              'CONSOLE_ORG_AUTH_REJECTED'
+            ),
+            { httpStatusCode: 401 }
+          );
+        }
+        throw Object.assign(
+          new ServerlessError(
+            'Unauthorized request: Run "sls login --console" to authenticate',
+            'CONSOLE_USER_AUTH_REJECTED'
+          ),
+          { httpStatusCode: 401 }
+        );
+      }
       throw Object.assign(new Error(`Console server error: [${response.status}] ${responseText}`), {
         code: `CONSOLE_SERVER_ERROR_${response.status}`,
         httpStatusCode: response.status,

--- a/test/api-request.test.js
+++ b/test/api-request.test.js
@@ -63,6 +63,7 @@ describe('test/api-request.test.js', () => {
                 }
                 if (url.includes('/unexpected-response/')) {
                   return {
+                    status: 200,
                     ok: true,
                     headers: responseHeaders,
                     json: async () => {
@@ -73,6 +74,7 @@ describe('test/api-request.test.js', () => {
                 }
                 if (url.includes('/success/')) {
                   return {
+                    status: 200,
                     ok: true,
                     headers: responseHeaders,
                     json: async () => ({ foo: 'bar' }),
@@ -82,6 +84,7 @@ describe('test/api-request.test.js', () => {
               case 'POST':
                 if (url.includes('/submission/')) {
                   return {
+                    status: 200,
                     ok: true,
                     headers: responseHeaders,
                     json: async () => ({ foo: 'bar' }),

--- a/test/api-request.test.js
+++ b/test/api-request.test.js
@@ -47,6 +47,20 @@ describe('test/api-request.test.js', () => {
                     text: async () => 'Programmer Error',
                   };
                 }
+                if (url.includes('/org-auth-error/')) {
+                  return {
+                    status: 401,
+                    headers: responseHeaders,
+                    text: async () => 'Org auth error',
+                  };
+                }
+                if (url.includes('/user-auth-error/')) {
+                  return {
+                    status: 401,
+                    headers: responseHeaders,
+                    text: async () => 'User auth Error',
+                  };
+                }
                 if (url.includes('/unexpected-response/')) {
                   return {
                     ok: true,
@@ -97,28 +111,24 @@ describe('test/api-request.test.js', () => {
     expect(lastRequestBody).to.equal('{"foo":"bar"}');
   });
 
-  it('should handle server unavailability', async () => {
+  it('should handle server unavailability', async () =>
     expect(api('/server-unavailable/')).to.eventually.be.rejected.and.have.property(
       'code',
       'CONSOLE_SERVER_UNAVAILABLE'
-    );
-  });
+    ));
 
-  it('should handle server error', async () => {
+  it('should handle server error', async () =>
     expect(api('/server-error/')).to.eventually.be.rejected.and.have.property(
       'code',
       'CONSOLE_SERVER_REQUEST_FAILED'
-    );
-  });
+    ));
 
-  it('should handle programmer error', async () => {
+  it('should handle programmer error', async () =>
     expect(api('/programmer-error/')).to.eventually.be.rejected.and.have.property(
       'code',
       'CONSOLE_SERVER_ERROR_400'
-    );
-  });
+    ));
 
-  it('should handle unexpected response', async () => {
-    expect(api('/unexpected-response/')).to.eventually.be.rejectedWith('Unexpected response');
-  });
+  it('should handle unexpected response', async () =>
+    expect(api('/unexpected-response/')).to.eventually.be.rejectedWith('Unexpected response'));
 });


### PR DESCRIPTION
Org token may not be supported for all operations, so in case of an `Unauthorized` error, it's good to communicate to users that they either use a wrong org token or should fallback to regular user login.

If `Unauthorized` happens on regular id token, show user error asking to re-login, instead of noisy programmer error listing direct response from the server. Such error can be the result of some reset on our authentication database side, or someone playing with the content of `.serverlessrc`