### PR TITLE
Auth: Support `clientOriginCommand` param

### DIFF
--- a/auth/login.js
+++ b/auth/login.js
@@ -129,6 +129,9 @@ module.exports = async (options = {}) => {
     transactionId: sessionId,
   });
   if (options.clientVersion) params.append('clientVersion', options.clientVersion);
+  if (options.clientOriginCommand) {
+    params.append('clientOriginCommand', options.clientOriginCommand);
+  }
 
   const loginUrl = `${urls.frontend}?${params}`;
   open(loginUrl);


### PR DESCRIPTION
For telemetry purposes, we want to send information on what command originated the login (there are two options `onboarding` and `login`).

This patch opens support for `clientOriginCommand` param as passed by the invoking utility