### PR TITLE
Auth: Fix race condition issues

### DIFF
--- a/auth/resolve-token.js
+++ b/auth/resolve-token.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const limit = require('ext/promise/limit').bind(Promise);
 const jwtDecode = require('jwt-decode');
 const fetch = require('node-fetch');
 const configUtils = require('../config');
@@ -19,7 +20,7 @@ if (process.env.SLS_ORG_TOKEN) {
   log.debug('consume org token');
 }
 
-module.exports = async () => {
+module.exports = limit(1, async () => {
   log.debug('start with cached data: %o, expires %d', data, idTokenExpiresAt);
   if (!data.idToken) {
     Object.assign(data, configUtils.get('auth'));
@@ -107,4 +108,4 @@ module.exports = async () => {
   idTokenExpiresAt = idTokenData.exp * 1000;
   configUtils.set({ auth: { idToken, refreshToken: responseObject.refreshToken } });
   return idToken;
-};
+});

--- a/auth/resolve-token.js
+++ b/auth/resolve-token.js
@@ -20,21 +20,23 @@ if (process.env.SLS_ORG_TOKEN) {
 }
 
 module.exports = async () => {
-  log.debug('cached data: %o, cached expires %d', data, idTokenExpiresAt);
+  log.debug('start with cached data: %o, expires %d', data, idTokenExpiresAt);
   if (!data.idToken) {
     Object.assign(data, configUtils.get('auth'));
+    log.debug('resolved data from config: %o', data);
     if (data.idToken) {
       const idTokenData = jwtDecode(data.idToken);
-      log.debug('id token data: %o', idTokenData);
+      log.debug('resolved id token from config: %o', idTokenData);
       idTokenExpiresAt = idTokenData.exp * 1000;
+      log.debug('resolved id token from config: %o, expires %d', idTokenData, idTokenExpiresAt);
     }
   }
   if (data.idToken) {
     if (idTokenExpiresAt > Date.now() + 500) {
-      log.debug('return valid token');
+      log.debug('valid token, return');
       return data.idToken;
     }
-    log.debug('token expired');
+    log.debug('token expired, clear, retrieve a new one');
     configUtils.delete('auth.idToken');
     idTokenExpiresAt = null;
   }


### PR DESCRIPTION
1. Prevent two parallel auth resolutions in the same process - as this may lead to one working with outdated auth tokens and producing 401 errors
2. Handle, if possible, cases where two parallel processes are authenticating with a console. In case of `refreshToken` mismatch, attempt to recover by retrieving authentication data as written by the other process