### PR TITLE
chore: Filter out stack trace from warning

### DIFF
--- a/console-ui.js
+++ b/console-ui.js
@@ -93,8 +93,8 @@ const formatConsoleEvent = (activity) => {
     }
   } else if (activity.eventName === 'telemetry.warning.generated.v1') {
     message = `WARNING • ${activity.tags.warning.message}`;
-    delete activity.tags.warning.stackTrace;
     payload = { ...activity.tags.warning, customTags };
+    delete payload.stackTrace;
   }
 
   return {

--- a/console-ui.js
+++ b/console-ui.js
@@ -93,10 +93,8 @@ const formatConsoleEvent = (activity) => {
     }
   } else if (activity.eventName === 'telemetry.warning.generated.v1') {
     message = `WARNING • ${activity.tags.warning.message}`;
-    const stackTrace = activity.tags.warning;
     delete activity.tags.warning.stackTrace;
     payload = { ...activity.tags.warning, customTags };
-    activity.tags.warning.stackTrace = stackTrace;
   }
 
   return {

--- a/console-ui.js
+++ b/console-ui.js
@@ -93,7 +93,10 @@ const formatConsoleEvent = (activity) => {
     }
   } else if (activity.eventName === 'telemetry.warning.generated.v1') {
     message = `WARNING • ${activity.tags.warning.message}`;
+    const stackTrace = activity.tags.warning;
+    delete activity.tags.warning.stackTrace;
     payload = { ...activity.tags.warning, customTags };
+    activity.tags.warning.stackTrace = stackTrace;
   }
 
   return {

--- a/test/console-ui.js
+++ b/test/console-ui.js
@@ -186,6 +186,7 @@ describe('Console UI', () => {
         customTags: JSON.stringify(customTags),
         tags: {
           warning: {
+            stackTrace: 'stack trace',
             message,
           },
         },
@@ -208,6 +209,7 @@ describe('Console UI', () => {
         customTags: JSON.stringify(customTags),
         tags: {
           warning: {
+            stackTrace: 'stack trace',
             message,
           },
         },


### PR DESCRIPTION
## Description
Filter out the `stackTrace` tag from warning tags so that customers don't have to see it.