### PR TITLE
fix: Stack trace should not be camel case

### DIFF
--- a/console-ui.js
+++ b/console-ui.js
@@ -94,7 +94,7 @@ const formatConsoleEvent = (activity) => {
   } else if (activity.eventName === 'telemetry.warning.generated.v1') {
     message = `WARNING • ${activity.tags.warning.message}`;
     payload = { ...activity.tags.warning, customTags };
-    delete payload.stackTrace;
+    delete payload.stacktrace;
   }
 
   return {

--- a/test/console-ui.js
+++ b/test/console-ui.js
@@ -186,7 +186,7 @@ describe('Console UI', () => {
         customTags: JSON.stringify(customTags),
         tags: {
           warning: {
-            stackTrace: 'stack trace',
+            stacktrace: 'stack trace',
             message,
           },
         },
@@ -209,7 +209,7 @@ describe('Console UI', () => {
         customTags: JSON.stringify(customTags),
         tags: {
           warning: {
-            stackTrace: 'stack trace',
+            stacktrace: 'stack trace',
             message,
           },
         },


### PR DESCRIPTION
## Description
🙄 I had this as `stacktrace` originally but copilot correct me to `stackTrace` and I believed it 🤖 