### PR TITLE
feat: Added no auth option to apiRequest

### DIFF
--- a/api-request.js
+++ b/api-request.js
@@ -17,13 +17,16 @@ module.exports = async (pathname, options = {}) => {
   if (!isObject(options)) options = {};
   const method = ensureString(options.method, { name: 'options.method', default: 'GET' });
   const body = ensurePlainObject(options.body, { name: 'options.body', isOptional: true });
-  const authMethod = await resolveAuthMethod();
+  const authMethod = options.noAuth ? 'none' : await resolveAuthMethod();
   if (!authMethod) throw new Error('Not authenticated to send request to the Console server');
   const requestId = ++requestIdCounter;
+  const authorization = options.noAuth
+    ? {}
+    : { Authorization: `Bearer ${await resolveAuthToken()}` };
   const response = await (async () => {
     const url = `${urls[options.urlName] || urls.backend}${pathname}`;
     const headers = {
-      'Authorization': `Bearer ${await resolveAuthToken()}`,
+      ...authorization,
       'Content-Type': 'application/json',
     };
     if (authMethod === 'org') headers['sls-token-type'] = 'orgToken';

--- a/test/api-request.test.js
+++ b/test/api-request.test.js
@@ -118,6 +118,11 @@ describe('test/api-request.test.js', () => {
     expect(lastRequestBody).to.equal('{"foo":"bar"}');
   });
 
+  it('should handle no auth option', async () => {
+    expect(await api('/success/', { noAuth: true })).to.deep.equal({ foo: 'bar' });
+    expect(!('Authorization' in lastRequestHeaders)).to.equal(true);
+  });
+
   it('should handle server unavailability', async () =>
     expect(api('/server-unavailable/')).to.eventually.be.rejected.and.have.property(
       'code',


### PR DESCRIPTION
## Description
Adding a no auth option to the api request library so that we can make requests with out a bearer token. This is helpful when we have some config options that we don't need to be logged in to look up like the console layer environment keys 👍  