### PR TITLE
Use green for success messages

### DIFF
--- a/lib/log-reporters/node/style.js
+++ b/lib/log-reporters/node/style.js
@@ -13,7 +13,7 @@ const cliStyle = {
   error: colorSupportLevel > 2 ? chalk.rgb(253, 87, 80) : chalk.redBright,
   link: identity,
   linkStrong: chalk.underline,
-  noticeSymbol: colorSupportLevel > 2 ? chalk.rgb(253, 87, 80) : chalk.redBright,
+  noticeSymbol: colorSupportLevel > 2 ? chalk.rgb(193, 224, 121) : chalk.greenBright,
   strong: colorSupportLevel > 2 ? chalk.rgb(253, 87, 80) : chalk.redBright,
   title: chalk.underline,
   warning: chalk.rgb(255, 165, 0),


### PR DESCRIPTION
After a successful deploy I often confuse the red ✔ for an error. I assume red was chosen for branding purposes, but it seems like it might be clearer for success messages to be shown in green.